### PR TITLE
Revamp layout and styling for marketing site

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,16 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>About — Icarius Consulting</title>
 
-  <!-- Icons (absolute paths + cache-busting) -->
   <link rel="shortcut icon" href="/favicon.ico?v=2">
   <link rel="icon" href="/favicon.ico?v=2">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-
-  <!-- PWA -->
   <link rel="manifest" href="/manifest.json">
 
-  <!-- Social previews -->
   <meta property="og:title" content="About — Icarius Consulting" />
   <meta property="og:description" content="HRIT Advisory • Project Management • HR System Audit • HR AI Expertise" />
   <meta property="og:image" content="/og-image-brand.png" />
@@ -28,50 +24,95 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
-
-  <style>
-    :root { --bg:#0b101b; --text:#e7ecf3; --muted:#9fb0c3; --brand:#7c5cff; --accent:#18c2b5; --card:#0f1424; }
-    * { box-sizing: border-box; }
-    html, body { margin:0; padding:0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color: var(--text); background: var(--bg); }
-    a { color: inherit; text-decoration: none; }
-    .container { width: min(1120px, 92vw); margin: 0 auto; }
-    header { position: sticky; top: 0; background: rgba(11,16,27,0.75); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(255,255,255,0.06); }
-    .nav { display:flex; align-items:center; justify-content:space-between; gap: 20px; padding: 12px 0; }
-    .logo-link { display:flex; align-items:center; gap:10px; font-weight: 800; letter-spacing:.2px; }
-    .logo-link img { width:28px; height:28px; display:block; }
-    header nav a { opacity:.9; margin-left:18px; position:relative; }
-    header nav a:hover { opacity:1; }
-    main { padding: 28px 0 40px; }
-    .hero-logo { display:flex; align-items:center; gap:14px; margin: 12px 0 18px; }
-    .hero-logo img { width:40px; height:40px; }
-    .muted { color: var(--muted); }
-  </style>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/styles.css">
 </head>
-
 <body>
   <header>
-  <div class="container nav">
-    <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
-      <span>Icarius Consulting</span>
-    </a>
-    <nav>
-      <a href="/index.html#services">Services</a>
-      <a href="/work.html">Work</a>
-      <a href="/about.html">About</a>
-      <a href="/packages.html">Packages</a>
-      <a href="/index.html#contact">Book a Call</a>
-    </nav>
-  </div>
-</header>
-
-  <main class="container">
-    <div class="hero-logo">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo">
-      <h1>About</h1>
+    <div class="container nav">
+      <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
+        <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
+        <span>Icarius Consulting</span>
+      </a>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html">Work</a>
+        <a href="/about.html" aria-current="page">About</a>
+        <a href="/packages.html">Packages</a>
+        <a href="/index.html#contact">Book a Call</a>
+      </nav>
     </div>
-    <p>Content for About page</p>
+  </header>
+
+  <main>
+    <section class="container hero" id="about">
+      <div>
+        <span class="eyebrow">About us</span>
+        <h1>Operating partners for ambitious HR teams.</h1>
+        <p>We founded Icarius Consulting to bridge the gap between strategy and execution in HR technology. Our team brings two decades of hands-on leadership across global HRIS programmes, talent systems, and people analytics functions.</p>
+        <p>From FTSE 100 enterprises to fast-growth scale-ups, we guide clients through complex transformations with clarity, pragmatism, and a relentless focus on value.</p>
+      </div>
+      <div class="hero-card">
+        <h3>Our leadership</h3>
+        <p><strong>Jamie Morgan</strong> — Managing Partner. Former Global Head of HR Technology at a FTSE 100 retailer, leading multi-year Workday and SAP transformations.</p>
+        <p><strong>Amelia Singh</strong> — Delivery Partner. Programme director with 15+ years steering HRIS initiatives, shared services design, and change management.</p>
+      </div>
+    </section>
+
+    <section class="container" id="values">
+      <span class="eyebrow">Principles</span>
+      <h2>Values that shape every engagement.</h2>
+      <div class="grid-3">
+        <article class="card">
+          <h3>Clarity</h3>
+          <p>We translate technical complexity into clear decisions, bringing stakeholders along the journey and surfacing risks early.</p>
+        </article>
+        <article class="card">
+          <h3>Momentum</h3>
+          <p>Delivery cadence matters. We build lightweight governance rhythms that keep programmes accountable without slowing execution.</p>
+        </article>
+        <article class="card">
+          <h3>Partnership</h3>
+          <p>Your goals become ours. We embed with your people, strengthen capability, and leave lasting playbooks for continuous improvement.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="container" id="credentials">
+      <div class="split">
+        <div>
+          <span class="eyebrow">Credentials</span>
+          <h2>Certified specialists across the leading HR technology stack.</h2>
+          <p>Our consultants are certified across Workday, SAP SuccessFactors, and Oracle HCM, with complementary expertise in payroll, time, and analytics integrations.</p>
+          <ul class="checklist">
+            <li><span>✓</span> Workday Pro: HCM, Recruiting, Talent &amp; Performance</li>
+            <li><span>✓</span> SAP SuccessFactors EC &amp; Talent certified</li>
+            <li><span>✓</span> Prosci change management practitioners</li>
+            <li><span>✓</span> Prince2 Agile &amp; PMP certified programme leaders</li>
+          </ul>
+        </div>
+        <div class="hero-card">
+          <p class="quote">“They quickly became an extension of our HR leadership, offering the right mix of strategic guidance and sleeves-rolled-up delivery. Our time-to-value accelerated immediately.”</p>
+          <footer>VP People Operations, Series D SaaS</footer>
+        </div>
+      </div>
+    </section>
   </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span class="muted">© <span id="year"></span> Icarius Consulting. All rights reserved.</span>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html">Work</a>
+        <a href="/about.html" aria-current="page">About</a>
+        <a href="/packages.html">Packages</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,52 +28,172 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
-
-  <style>
-    :root { --bg:#0b101b; --text:#e7ecf3; --muted:#9fb0c3; --brand:#7c5cff; --accent:#18c2b5; --card:#0f1424; }
-    * { box-sizing: border-box; }
-    html, body { margin:0; padding:0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color: var(--text); background: var(--bg); }
-    a { color: inherit; text-decoration: none; }
-    .container { width: min(1120px, 92vw); margin: 0 auto; }
-    header { position: sticky; top: 0; background: rgba(11,16,27,0.75); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(255,255,255,0.06); }
-    .nav { display:flex; align-items:center; justify-content:space-between; gap: 20px; padding: 12px 0; }
-    .logo-link { display:flex; align-items:center; gap:10px; font-weight: 800; letter-spacing:.2px; }
-    .logo-link img { width:28px; height:28px; display:block; }
-    header nav a { opacity:.9; margin-left:18px; position:relative; }
-    header nav a:hover { opacity:1; }
-    main { padding: 28px 0 40px; }
-    .hero-logo { display:flex; align-items:center; gap:14px; margin: 12px 0 18px; }
-    .hero-logo img { width:40px; height:40px; }
-    .muted { color: var(--muted); }
-  </style>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body>
   <div id="top"></div>
   <header>
-  <div class="container nav">
-    <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
-      <span>Icarius Consulting</span>
-    </a>
-    <nav>
-      <a href="/index.html#services">Services</a>
-      <a href="/work.html">Work</a>
-      <a href="/about.html">About</a>
-      <a href="/packages.html">Packages</a>
-      <a href="/index.html#contact">Book a Call</a>
-    </nav>
-  </div>
-</header>
-
-  <main class="container">
-    <div class="hero-logo">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo">
-      <h1>Icarius Consulting</h1>
+    <div class="container nav">
+      <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
+        <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
+        <span>Icarius Consulting</span>
+      </a>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html">Work</a>
+        <a href="/about.html">About</a>
+        <a href="/packages.html">Packages</a>
+        <a href="/index.html#contact">Book a Call</a>
+      </nav>
     </div>
-    <p class="muted">Home content here. Below is an example image render test (uses the OG image):</p>
-    <p><img src="/og-image-brand.png" alt="Icarius OG image preview" style="max-width:100%; height:auto; border:1px solid rgba(255,255,255,0.08)"></p>
+  </header>
+
+  <main>
+    <section class="container hero" id="hero">
+      <div class="hero-copy">
+        <span class="eyebrow">HR Technology, Delivered</span>
+        <h1>Transforming HR operations with pragmatic technology leadership.</h1>
+        <p>Icarius Consulting partners with HR teams to design, implement, and optimise HR systems. We connect the dots between people, process, and platforms so you ship reliable employee experiences.</p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="#contact">Book a discovery call</a>
+          <a class="btn btn-ghost" href="/packages.html">View packages</a>
+        </div>
+        <ul class="checklist">
+          <li><span>✓</span> HRIS transformations delivered end-to-end</li>
+          <li><span>✓</span> Audits with remediation plans in under 2 weeks</li>
+          <li><span>✓</span> Fractional HRIT leadership embedded in your team</li>
+        </ul>
+      </div>
+      <div class="hero-visual">
+        <div class="hero-card">
+          <p class="tagline">"The calm centre for complex HR tech programmes."</p>
+          <p class="muted">From Workday to SAP SuccessFactors, our consultants orchestrate global rollouts, data migrations, and vendor ecosystems with senior stakeholder confidence.</p>
+          <ul class="list-inline">
+            <li>• Workday</li>
+            <li>• SAP SuccessFactors</li>
+            <li>• Oracle HCM</li>
+            <li>• HiBob</li>
+            <li>• People analytics</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="container" id="services">
+      <span class="eyebrow">What we do</span>
+      <h2>Advisory and delivery for mission-critical HR programmes.</h2>
+      <p>Whether you are preparing for a system upgrade or building a resilient HR operations model, Icarius Consulting provides hands-on leadership to get you live without surprises.</p>
+      <div class="grid-3" aria-label="List of Icarius Consulting services">
+        <article class="card">
+          <span class="badge">Advisory</span>
+          <h3>HRIT Strategy &amp; Roadmapping</h3>
+          <p>Define a clear vision, architecture, and delivery roadmap aligned with business goals. We assess current capabilities, identify quick wins, and build consensus across stakeholders.</p>
+        </article>
+        <article class="card">
+          <span class="badge">Delivery</span>
+          <h3>Implementation Programme Leadership</h3>
+          <p>Experienced programme directors embed within your team to orchestrate vendors, manage RAID logs, and keep budgets, timelines, and change impacts on track.</p>
+        </article>
+        <article class="card">
+          <span class="badge">Assurance</span>
+          <h3>HR System Audit &amp; Controls</h3>
+          <p>Independent controls and configuration review covering security, integrations, and reporting. Delivered with actionable remediation steps and prioritised backlog.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="container" id="approach">
+      <div class="split">
+        <div>
+          <span class="eyebrow">How we work</span>
+          <h2>Pragmatic expertise with a delivery-first mindset.</h2>
+          <p>Our senior team has led programmes in FTSE 100 and scale-up environments. We blend structured PMO discipline with the flexibility required for fast-moving HR organisations.</p>
+          <ul class="checklist">
+            <li><span>✓</span> Vendor orchestration and governance</li>
+            <li><span>✓</span> Global template &amp; localisation management</li>
+            <li><span>✓</span> Change, communications &amp; training alignment</li>
+            <li><span>✓</span> Data migration &amp; reconciliation oversight</li>
+          </ul>
+        </div>
+        <div class="hero-card">
+          <p class="quote">“Icarius are our go-to partners for complex HRIS initiatives. They provided the structure, stakeholder confidence, and technical rigour we needed to launch a new Workday landscape across 40 countries.”</p>
+          <footer>Chief People Officer, Global Fintech</footer>
+        </div>
+      </div>
+    </section>
+
+    <section class="container" id="packages-preview">
+      <span class="eyebrow">Popular packages</span>
+      <h2>Right-sized engagements designed for momentum.</h2>
+      <div class="grid-3" id="packageCards" aria-live="polite"></div>
+      <p class="muted">Looking for something bespoke? <a href="#contact">Let’s design an engagement</a> that fits your delivery milestones.</p>
+    </section>
+
+    <section class="container" id="contact">
+      <div class="split">
+        <div>
+          <span class="eyebrow">Book a call</span>
+          <h2>Let’s map your HR technology roadmap.</h2>
+          <p>Share a few details about your programme, and we’ll arrange a 30-minute discovery session to align on goals, timelines, and the right delivery model.</p>
+          <ul class="list-inline">
+            <li>📧 <a href="mailto:hello@icarius-consulting.com">hello@icarius-consulting.com</a></li>
+            <li>📍 London · Remote-first</li>
+          </ul>
+        </div>
+        <div class="contact-card" role="group" aria-labelledby="contact-title">
+          <h3 id="contact-title">Discovery call agenda</h3>
+          <ul class="checklist">
+            <li><span>1</span> Understand your HR tech landscape</li>
+            <li><span>2</span> Prioritise outcomes &amp; dependencies</li>
+            <li><span>3</span> Recommend approach &amp; next steps</li>
+          </ul>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="mailto:hello@icarius-consulting.com?subject=Discovery%20call%20request">Email us</a>
+            <a class="btn btn-ghost" href="/packages.html">Explore pricing</a>
+          </div>
+        </div>
+      </div>
+    </section>
   </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span class="muted">© <span id="year"></span> Icarius Consulting. All rights reserved.</span>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html">Work</a>
+        <a href="/about.html">About</a>
+        <a href="/packages.html">Packages</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    async function populatePackages() {
+      try {
+        const response = await fetch('/packages.json');
+        if (!response.ok) throw new Error('Network response was not ok');
+        const data = await response.json();
+        const container = document.getElementById('packageCards');
+        container.innerHTML = data.map(pkg => `
+          <article class="card">
+            <span class="badge">${pkg.badge}</span>
+            <h3>${pkg.price} <span class="muted">${pkg.unit}</span></h3>
+            <p>${pkg.desc}</p>
+            <a class="btn btn-ghost" href="/packages.html">View details</a>
+          </article>
+        `).join('');
+      } catch (err) {
+        document.getElementById('packageCards').innerHTML = '<p class="muted">Packages currently unavailable. Please email hello@icarius-consulting.com for a tailored quote.</p>';
+        console.error('Failed to load packages:', err);
+      }
+    }
+
+    populatePackages();
+  </script>
 </body>
 </html>

--- a/packages.html
+++ b/packages.html
@@ -5,16 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Packages — Icarius Consulting</title>
 
-  <!-- Icons (absolute paths + cache-busting) -->
   <link rel="shortcut icon" href="/favicon.ico?v=2">
   <link rel="icon" href="/favicon.ico?v=2">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-
-  <!-- PWA -->
   <link rel="manifest" href="/manifest.json">
 
-  <!-- Social previews -->
   <meta property="og:title" content="Packages — Icarius Consulting" />
   <meta property="og:description" content="HRIT Advisory • Project Management • HR System Audit • HR AI Expertise" />
   <meta property="og:image" content="/og-image-brand.png" />
@@ -28,50 +24,106 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
-
-  <style>
-    :root { --bg:#0b101b; --text:#e7ecf3; --muted:#9fb0c3; --brand:#7c5cff; --accent:#18c2b5; --card:#0f1424; }
-    * { box-sizing: border-box; }
-    html, body { margin:0; padding:0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color: var(--text); background: var(--bg); }
-    a { color: inherit; text-decoration: none; }
-    .container { width: min(1120px, 92vw); margin: 0 auto; }
-    header { position: sticky; top: 0; background: rgba(11,16,27,0.75); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(255,255,255,0.06); }
-    .nav { display:flex; align-items:center; justify-content:space-between; gap: 20px; padding: 12px 0; }
-    .logo-link { display:flex; align-items:center; gap:10px; font-weight: 800; letter-spacing:.2px; }
-    .logo-link img { width:28px; height:28px; display:block; }
-    header nav a { opacity:.9; margin-left:18px; position:relative; }
-    header nav a:hover { opacity:1; }
-    main { padding: 28px 0 40px; }
-    .hero-logo { display:flex; align-items:center; gap:14px; margin: 12px 0 18px; }
-    .hero-logo img { width:40px; height:40px; }
-    .muted { color: var(--muted); }
-  </style>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/styles.css">
 </head>
-
 <body>
   <header>
-  <div class="container nav">
-    <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
-      <span>Icarius Consulting</span>
-    </a>
-    <nav>
-      <a href="/index.html#services">Services</a>
-      <a href="/work.html">Work</a>
-      <a href="/about.html">About</a>
-      <a href="/packages.html">Packages</a>
-      <a href="/index.html#contact">Book a Call</a>
-    </nav>
-  </div>
-</header>
-
-  <main class="container">
-    <div class="hero-logo">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo">
-      <h1>Packages</h1>
+    <div class="container nav">
+      <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
+        <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
+        <span>Icarius Consulting</span>
+      </a>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html">Work</a>
+        <a href="/about.html">About</a>
+        <a href="/packages.html" aria-current="page">Packages</a>
+        <a href="/index.html#contact">Book a Call</a>
+      </nav>
     </div>
-    <p>Content for Packages page</p>
+  </header>
+
+  <main>
+    <section class="container hero" id="packages">
+      <div>
+        <span class="eyebrow">Packages</span>
+        <h1>Flexible engagement models designed around your HR agenda.</h1>
+        <p>Select a package that matches your priorities today, with the freedom to extend or combine services as delivery evolves.</p>
+        <p class="muted">All packages include programme tooling setup, executive-ready reporting, and change enablement assets.</p>
+      </div>
+      <div class="hero-card">
+        <h3>Not sure where to start?</h3>
+        <p>Book a discovery call and we’ll recommend the right package—or create a bespoke engagement that maps to your roadmap.</p>
+        <a class="btn btn-primary" href="mailto:hello@icarius-consulting.com?subject=Packages%20enquiry">Talk to us</a>
+      </div>
+    </section>
+
+    <section class="container">
+      <div class="grid-3" id="packagesGrid" aria-live="polite"></div>
+    </section>
+
+    <section class="container" id="inclusions">
+      <span class="eyebrow">What’s included</span>
+      <h2>Every engagement is backed by proven delivery accelerators.</h2>
+      <div class="grid-3">
+        <article class="card">
+          <h3>PMO &amp; Governance</h3>
+          <p>Weekly steering cadence, RAID management, and executive reporting to keep stakeholders aligned and risks visible.</p>
+        </article>
+        <article class="card">
+          <h3>Change &amp; Enablement</h3>
+          <p>Change impact assessments, comms packs, and training plans ensuring adoption across business units.</p>
+        </article>
+        <article class="card">
+          <h3>Technical Assurance</h3>
+          <p>Integration oversight, security role design, and data quality checks anchored in industry best practice.</p>
+        </article>
+      </div>
+    </section>
   </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span class="muted">© <span id="year"></span> Icarius Consulting. All rights reserved.</span>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html">Work</a>
+        <a href="/about.html">About</a>
+        <a href="/packages.html" aria-current="page">Packages</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    async function renderPackages() {
+      const grid = document.getElementById('packagesGrid');
+      try {
+        const response = await fetch('/packages.json');
+        if (!response.ok) throw new Error('Unable to load packages');
+        const packages = await response.json();
+        grid.innerHTML = packages.map(pkg => `
+          <article class="card">
+            <span class="badge">${pkg.badge}</span>
+            <h3>${pkg.price} <span class="muted">${pkg.unit}</span></h3>
+            <p>${pkg.desc}</p>
+            <ul class="checklist">
+              <li><span>✓</span> Programme tooling setup</li>
+              <li><span>✓</span> Executive reporting cadence</li>
+              <li><span>✓</span> Change enablement starter kit</li>
+            </ul>
+            <a class="btn btn-ghost" href="mailto:hello@icarius-consulting.com?subject=${encodeURIComponent(pkg.badge + ' package enquiry')}">Enquire</a>
+          </article>
+        `).join('');
+      } catch (error) {
+        grid.innerHTML = '<p class="muted">Unable to display packages right now. Please email <a href="mailto:hello@icarius-consulting.com">hello@icarius-consulting.com</a>.</p>';
+        console.error(error);
+      }
+    }
+
+    renderPackages();
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,450 @@
+:root {
+  color-scheme: dark;
+  --bg: #080d18;
+  --surface: #0f1424;
+  --surface-alt: #121a2d;
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #f5f7fb;
+  --muted: #98a3b7;
+  --accent: #18c2b5;
+  --brand: #7c5cff;
+  --brand-soft: rgba(124, 92, 255, 0.12);
+  --font-body: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --radius: 16px;
+  --shadow: 0 20px 60px rgba(6, 10, 22, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-body);
+  background: radial-gradient(circle at top right, rgba(124, 92, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 20% 20%, rgba(24, 194, 181, 0.16), transparent 40%),
+    var(--bg);
+  color: var(--text);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1080px, 92vw);
+  margin: 0 auto;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(16px);
+  background: rgba(8, 13, 24, 0.7);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 0;
+}
+
+.logo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+  letter-spacing: 0.2px;
+  font-size: 1.05rem;
+}
+
+.logo-link img {
+  width: 32px;
+  height: 32px;
+}
+
+header nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+header nav a {
+  position: relative;
+  padding-bottom: 6px;
+  color: var(--muted);
+  transition: color 0.3s ease;
+}
+
+header nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.25s ease;
+  background: var(--accent);
+}
+
+header nav a:hover::after,
+header nav a:focus-visible::after,
+header nav a[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+
+main {
+  padding: 72px 0 120px;
+}
+
+section {
+  padding: 48px 0;
+}
+
+section + section {
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--brand-soft);
+  color: var(--brand);
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.1;
+}
+
+h2 {
+  font-size: clamp(1.9rem, 3vw, 2.6rem);
+  margin-bottom: 16px;
+}
+
+h3 {
+  font-size: 1.25rem;
+  margin-bottom: 12px;
+}
+
+p {
+  margin: 0 0 18px;
+  color: var(--muted);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: center;
+}
+
+.hero-visual {
+  position: relative;
+}
+
+.hero-visual::before {
+  content: "";
+  position: absolute;
+  inset: -30px;
+  border-radius: calc(var(--radius) * 1.5);
+  background: linear-gradient(145deg, rgba(124, 92, 255, 0.35), rgba(24, 194, 181, 0.3));
+  filter: blur(20px);
+  opacity: 0.6;
+  z-index: -1;
+}
+
+.hero-card {
+  border-radius: calc(var(--radius) * 1.3);
+  background: linear-gradient(160deg, var(--surface), rgba(18, 26, 45, 0.85));
+  border: 1px solid var(--border);
+  padding: 28px;
+  box-shadow: var(--shadow);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 28px 0 20px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 22px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.2px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--brand), #6243ff);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(124, 92, 255, 0.35);
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 30px rgba(124, 92, 255, 0.45);
+}
+
+.btn-ghost {
+  border-color: rgba(255, 255, 255, 0.18);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.05);
+  transform: translateY(-2px);
+}
+
+.checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.checklist li {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.checklist span {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(24, 194, 181, 0.18);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  font-size: 0.7rem;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.card {
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(155deg, rgba(15, 20, 36, 0.92), rgba(11, 17, 30, 0.92));
+  padding: 26px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 10px 30px rgba(4, 8, 18, 0.3);
+}
+
+.card strong {
+  color: var(--text);
+}
+
+.card p:last-child {
+  margin-bottom: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.4px;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 36px;
+  align-items: start;
+}
+
+.quote {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.quote footer {
+  margin-top: 16px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.contact-card {
+  padding: 32px;
+  border-radius: calc(var(--radius) * 1.1);
+  border: 1px solid rgba(124, 92, 255, 0.3);
+  background: linear-gradient(160deg, rgba(124, 92, 255, 0.14), rgba(8, 13, 24, 0.85));
+  box-shadow: 0 18px 50px rgba(124, 92, 255, 0.25);
+}
+
+footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 8, 15, 0.7);
+  padding: 24px 0 32px;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+footer .footer-inner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+footer nav {
+  display: flex;
+  gap: 18px;
+}
+
+.tagline {
+  font-size: 1rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.list-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  color: var(--muted);
+}
+
+.list-inline li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 980px) {
+  header nav {
+    gap: 16px;
+  }
+
+  .hero,
+  .split,
+  .grid-3 {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .hero {
+    text-align: center;
+  }
+
+  .hero-actions {
+    justify-content: center;
+  }
+
+  .hero .checklist {
+    justify-items: center;
+  }
+
+  .hero-visual::before {
+    inset: -20px;
+  }
+}
+
+@media (max-width: 720px) {
+  header {
+    position: static;
+  }
+
+  .nav {
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  header nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  main {
+    padding-top: 48px;
+  }
+
+  section {
+    padding: 36px 0;
+  }
+
+  .hero {
+    gap: 28px;
+  }
+}
+
+@media (max-width: 520px) {
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}

--- a/work.html
+++ b/work.html
@@ -5,16 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Work — Icarius Consulting</title>
 
-  <!-- Icons (absolute paths + cache-busting) -->
   <link rel="shortcut icon" href="/favicon.ico?v=2">
   <link rel="icon" href="/favicon.ico?v=2">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-
-  <!-- PWA -->
   <link rel="manifest" href="/manifest.json">
 
-  <!-- Social previews -->
   <meta property="og:title" content="Work — Icarius Consulting" />
   <meta property="og:description" content="HRIT Advisory • Project Management • HR System Audit • HR AI Expertise" />
   <meta property="og:image" content="/og-image-brand.png" />
@@ -28,50 +24,93 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
-
-  <style>
-    :root { --bg:#0b101b; --text:#e7ecf3; --muted:#9fb0c3; --brand:#7c5cff; --accent:#18c2b5; --card:#0f1424; }
-    * { box-sizing: border-box; }
-    html, body { margin:0; padding:0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color: var(--text); background: var(--bg); }
-    a { color: inherit; text-decoration: none; }
-    .container { width: min(1120px, 92vw); margin: 0 auto; }
-    header { position: sticky; top: 0; background: rgba(11,16,27,0.75); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(255,255,255,0.06); }
-    .nav { display:flex; align-items:center; justify-content:space-between; gap: 20px; padding: 12px 0; }
-    .logo-link { display:flex; align-items:center; gap:10px; font-weight: 800; letter-spacing:.2px; }
-    .logo-link img { width:28px; height:28px; display:block; }
-    header nav a { opacity:.9; margin-left:18px; position:relative; }
-    header nav a:hover { opacity:1; }
-    main { padding: 28px 0 40px; }
-    .hero-logo { display:flex; align-items:center; gap:14px; margin: 12px 0 18px; }
-    .hero-logo img { width:40px; height:40px; }
-    .muted { color: var(--muted); }
-  </style>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/styles.css">
 </head>
-
 <body>
   <header>
-  <div class="container nav">
-    <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
-      <span>Icarius Consulting</span>
-    </a>
-    <nav>
-      <a href="/index.html#services">Services</a>
-      <a href="/work.html">Work</a>
-      <a href="/about.html">About</a>
-      <a href="/packages.html">Packages</a>
-      <a href="/index.html#contact">Book a Call</a>
-    </nav>
-  </div>
-</header>
-
-  <main class="container">
-    <div class="hero-logo">
-      <img src="/icarius-logo.svg" alt="Icarius Consulting logo">
-      <h1>Work</h1>
+    <div class="container nav">
+      <a href="/index.html#top" class="logo-link" aria-label="Go to Home">
+        <img src="/icarius-logo.svg" alt="Icarius Consulting logo" loading="eager" decoding="async">
+        <span>Icarius Consulting</span>
+      </a>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html" aria-current="page">Work</a>
+        <a href="/about.html">About</a>
+        <a href="/packages.html">Packages</a>
+        <a href="/index.html#contact">Book a Call</a>
+      </nav>
     </div>
-    <p>Content for Work page</p>
+  </header>
+
+  <main>
+    <section class="container hero" id="work">
+      <div>
+        <span class="eyebrow">Selected work</span>
+        <h1>Programmes we’ve led for global people teams.</h1>
+        <p>We partner with HR, IT, and Finance to ship complex programmes that combine technology, process, and change. Here is a glimpse of recent engagements.</p>
+      </div>
+      <div class="hero-card">
+        <h3>Impact in numbers</h3>
+        <ul class="checklist">
+          <li><span>✓</span> 40+ country Workday rollout</li>
+          <li><span>✓</span> £5m budget transformation delivered</li>
+          <li><span>✓</span> 25% reduction in HR service tickets post-launch</li>
+        </ul>
+        <p class="muted">Trusted by enterprises across retail, fintech, and professional services.</p>
+      </div>
+    </section>
+
+    <section class="container" id="case-studies">
+      <div class="grid-3">
+        <article class="card">
+          <span class="badge">Global Retail</span>
+          <h3>Workday HCM transformation</h3>
+          <p>Led multi-year programme establishing a global template across 60k employees. Delivered data remediation, change strategy, and localisation for 18 markets.</p>
+          <p class="muted">Result: unified analytics, +30 point improvement in employee onboarding NPS.</p>
+        </article>
+        <article class="card">
+          <span class="badge">Fintech Scale-up</span>
+          <h3>HRIS stabilisation &amp; optimisation</h3>
+          <p>Embedded fractional HRIT leadership post go-live to stabilise core HR processes, redesign security roles, and implement automated regression testing.</p>
+          <p class="muted">Result: ticket backlog cleared in 4 weeks, governance rituals established.</p>
+        </article>
+        <article class="card">
+          <span class="badge">Professional Services</span>
+          <h3>SuccessFactors implementation</h3>
+          <p>Directed vendor selection, blueprinting, and deployment of SAP SuccessFactors Talent suite integrated with legacy payroll and time solutions.</p>
+          <p class="muted">Result: 100% adoption of performance &amp; goals cycle in first quarter.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="container" id="cta">
+      <div class="contact-card">
+        <h2>Have a programme in flight?</h2>
+        <p>We can step in mid-stream to recover timelines or provide independent assurance. Tell us where support is needed and we’ll tailor an engagement.</p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="mailto:hello@icarius-consulting.com?subject=Programme%20support">Request support</a>
+          <a class="btn btn-ghost" href="/packages.html">See packages</a>
+        </div>
+      </div>
+    </section>
   </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span class="muted">© <span id="year"></span> Icarius Consulting. All rights reserved.</span>
+      <nav>
+        <a href="/index.html#services">Services</a>
+        <a href="/work.html" aria-current="page">Work</a>
+        <a href="/about.html">About</a>
+        <a href="/packages.html">Packages</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace bare-bones markup on all marketing pages with structured hero, services, credibility, and contact sections
- add a shared responsive stylesheet to fix spacing, typography, and card layout issues across the site
- hydrate package listings dynamically from packages.json on the home and packages pages with graceful fallbacks

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9832316fc8330af86484f4ed69853