### PR TITLE
Add Services link to primary navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -236,6 +236,7 @@
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html" class="active">About</a></li>
+          <li><a href="services.html">Services</a></li>
           <li><a href="work.html">Work</a></li>
           <li><a href="packages.html">Packages</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -277,6 +277,7 @@
         <ul class="nav-links">
           <li><a href="index.html" class="active">Home</a></li>
           <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Services</a></li>
           <li><a href="work.html">Work</a></li>
           <li><a href="packages.html">Packages</a></li>
         </ul>

--- a/packages.html
+++ b/packages.html
@@ -289,6 +289,7 @@
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Services</a></li>
           <li><a href="work.html">Work</a></li>
           <li><a href="packages.html" class="active">Packages</a></li>
         </ul>

--- a/work.html
+++ b/work.html
@@ -281,6 +281,7 @@
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Services</a></li>
           <li><a href="work.html" class="active">Work</a></li>
           <li><a href="packages.html">Packages</a></li>
         </ul>


### PR DESCRIPTION
## Summary
- add the Services link to the primary navigation on the home, about, work, and packages pages
- keep existing active-state styling intact for each page

## Testing
- Manually viewed the sticky header at desktop and mobile widths

------
https://chatgpt.com/codex/tasks/task_e_68d9a52090688330bda8815c373e127e