### PR TITLE
Remove Our Services section from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,34 +298,6 @@
         </div>
       </div>
     </section>
-
-    <section class="section">
-      <div class="container">
-        <h2>Our Services</h2>
-        <div class="services">
-          <div class="service-card">
-            <div class="service-icon">🚀</div>
-            <h3>HRIT Advisory</h3>
-            <p>Strategic guidance for HR technology transformation and digital innovation initiatives.</p>
-          </div>
-          <div class="service-card">
-            <div class="service-icon">📈</div>
-            <h3>Project Management</h3>
-            <p>End-to-end leadership for complex HR system implementations and organizational change.</p>
-          </div>
-          <div class="service-card">
-            <div class="service-icon">🔍</div>
-            <h3>System Audits</h3>
-            <p>Comprehensive analysis and optimization recommendations for your HR technology stack.</p>
-          </div>
-          <div class="service-card">
-            <div class="service-icon">🤖</div>
-            <h3>HR AI Solutions</h3>
-            <p>Cutting-edge artificial intelligence applications for recruitment, performance, and analytics.</p>
-          </div>
-        </div>
-      </div>
-    </section>
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
- remove the Our Services section from the homepage
- ensure the main element closes immediately after the hero section

## Testing
- no tests were run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d9aab00f648330b4c53e49fcc80872