### PR TITLE
Add footer breadcrumb navigation to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,6 +340,15 @@
 
   <footer>
     <div class="container">
+      <nav class="footer-breadcrumb" aria-label="Breadcrumb">
+        <ol class="breadcrumb-list">
+          <li class="breadcrumb-item"><a href="index.html" aria-current="page">Home</a></li>
+          <li class="breadcrumb-item"><a href="about.html">About</a></li>
+          <li class="breadcrumb-item"><a href="services.html">Services</a></li>
+          <li class="breadcrumb-item"><a href="work.html">Work</a></li>
+          <li class="breadcrumb-item"><a href="packages.html">Packages</a></li>
+        </ol>
+      </nav>
       <p>&copy; 2024 Icarius Consulting. All rights reserved.</p>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- add a footer breadcrumb navigation to mirror the header path
- ensure the Home link is marked as the current page in the footer

## Testing
- Viewed in browser

------
https://chatgpt.com/codex/tasks/task_e_68d9af3319a08330b21234de342a4be8