### PR TITLE
Add contact link to site navigation and update services CTA

### DIFF
--- a/about.html
+++ b/about.html
@@ -239,6 +239,7 @@
           <li><a href="services.html">Services</a></li>
           <li><a href="work.html">Work</a></li>
           <li><a href="packages.html">Packages</a></li>
+          <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -99,6 +99,8 @@
       list-style: none;
       margin: 0;
       padding: 0;
+      flex-wrap: wrap;
+      justify-content: flex-end;
     }
 
     .nav-links a {
@@ -343,10 +345,10 @@
         </a>
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>
-          <li><a href="services.html">Services</a></li>
-          <li><a href="packages.html">Packages</a></li>
-          <li><a href="work.html">Work</a></li>
           <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Services</a></li>
+          <li><a href="work.html">Work</a></li>
+          <li><a href="packages.html">Packages</a></li>
           <li><a href="contact.html" class="active">Contact</a></li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,29 @@
       height: 32px;
     }
 
+    .nav-links {
+      display: flex;
+      gap: 1.75rem;
+      list-style: none;
+      margin: 0;
+      margin-left: auto;
+      padding: 0;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .nav-links a {
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 500;
+      transition: color 0.3s ease;
+    }
+
+    .nav-links a:hover,
+    .nav-links a.active {
+      color: var(--text);
+    }
+
     .breadcrumb-nav {
       margin-left: auto;
     }
@@ -267,15 +290,16 @@
     }
 
     @media (max-width: 768px) {
-      .breadcrumb-nav {
-        margin-left: 0;
+      .nav-links {
+        gap: 1rem;
+        font-size: 0.95rem;
       }
 
       .breadcrumb-list {
         gap: 0.75rem;
         font-size: 0.95rem;
         flex-wrap: wrap;
-        justify-content: flex-end;
+        justify-content: center;
       }
 
       .breadcrumb-item {
@@ -285,7 +309,7 @@
       .hero h1 {
         font-size: 2.5rem;
       }
-      
+
       .hero .subtitle {
         font-size: 1.25rem;
       }
@@ -310,15 +334,14 @@
           <img src="logo.svg" alt="Icarius Consulting">
           Icarius
         </a>
-        <nav class="breadcrumb-nav" aria-label="Breadcrumb">
-          <ol class="breadcrumb-list">
-            <li class="breadcrumb-item"><a href="index.html" aria-current="page">Home</a></li>
-            <li class="breadcrumb-item"><a href="about.html">About</a></li>
-            <li class="breadcrumb-item"><a href="services.html">Services</a></li>
-            <li class="breadcrumb-item"><a href="work.html">Work</a></li>
-            <li class="breadcrumb-item"><a href="packages.html">Packages</a></li>
-          </ol>
-        </nav>
+        <ul class="nav-links">
+          <li><a href="index.html" class="active">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="services.html">Services</a></li>
+          <li><a href="work.html">Work</a></li>
+          <li><a href="packages.html">Packages</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
       </nav>
     </div>
   </header>
@@ -347,6 +370,7 @@
           <li class="breadcrumb-item"><a href="services.html">Services</a></li>
           <li class="breadcrumb-item"><a href="work.html">Work</a></li>
           <li class="breadcrumb-item"><a href="packages.html">Packages</a></li>
+          <li class="breadcrumb-item"><a href="contact.html">Contact</a></li>
         </ol>
       </nav>
       <p>&copy; 2024 Icarius Consulting. All rights reserved.</p>

--- a/packages.html
+++ b/packages.html
@@ -292,6 +292,7 @@
           <li><a href="services.html">Services</a></li>
           <li><a href="work.html">Work</a></li>
           <li><a href="packages.html" class="active">Packages</a></li>
+          <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
     </div>

--- a/services.html
+++ b/services.html
@@ -75,9 +75,48 @@
     .logo-link { display:flex; align-items:center; gap:12px; font-weight:700; letter-spacing:0.02em; }
     .logo-link img { width:32px; height:32px; }
 
-    nav a { margin-left: 20px; font-weight:500; opacity:0.82; transition: opacity 0.2s ease, color 0.2s ease; }
-    nav a:first-child { margin-left:0; }
-    nav a:hover, nav a:focus-visible { opacity:1; color: var(--accent); }
+    .primary-nav { display:flex; align-items:center; gap:1.75rem; }
+
+    .nav-links {
+      display: flex;
+      list-style: none;
+      gap: 1.75rem;
+      margin: 0;
+      padding: 0;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .nav-links a {
+      font-weight: 500;
+      opacity: 0.82;
+      transition: opacity 0.2s ease, color 0.2s ease;
+    }
+
+    .nav-links a:hover,
+    .nav-links a:focus-visible,
+    .nav-links a.active {
+      opacity: 1;
+      color: var(--accent);
+    }
+
+    .cta-button {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.55rem 1.25rem;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 12px 32px rgba(24, 194, 181, 0.35);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .cta-button:hover,
+    .cta-button:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 36px rgba(24, 194, 181, 0.4);
+    }
 
     main { padding: 56px 0 120px; }
 
@@ -120,7 +159,16 @@
     }
 
     @media (max-width: 720px) {
-      nav a { margin-left: 14px; }
+      .primary-nav {
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 1rem;
+      }
+
+      .nav-links {
+        gap: 1rem;
+      }
+
       .card { padding: 24px; }
     }
   </style>
@@ -132,12 +180,16 @@
         <img src="icarius-logo.svg" alt="Icarius Consulting logo">
         <span>Icarius Consulting</span>
       </a>
-      <nav>
-        <a href="services.html">Services</a>
-        <a href="work.html">Work</a>
-        <a href="about.html">About</a>
-        <a href="packages.html">Packages</a>
-        <a href="index.html#contact">Book a Call</a>
+      <nav class="primary-nav" aria-label="Primary">
+        <ul class="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="services.html" class="active">Services</a></li>
+          <li><a href="work.html">Work</a></li>
+          <li><a href="packages.html">Packages</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+        <a class="cta-button" href="index.html#contact">Book a Call</a>
       </nav>
     </div>
   </header>

--- a/work.html
+++ b/work.html
@@ -284,6 +284,7 @@
           <li><a href="services.html">Services</a></li>
           <li><a href="work.html" class="active">Work</a></li>
           <li><a href="packages.html">Packages</a></li>
+          <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- add the Contact destination to the primary navigation on the home, about, work, packages, services, and contact pages with consistent active styling
- refactor the services header to keep the Book a Call action outside the main menu while matching the link order used elsewhere
- update the home and contact layouts so navigation spacing remains intact after the new item, and mirror the Contact link in the footer breadcrumb

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9b21d1f408330ae420b7d1ef530ed