### PR TITLE
Add chatbot widget and serverless chat request handler

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,1 +1,124 @@
-<!-- custom branded 404.html with logo + return home -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Page Not Found — Icarius Consulting</title>
+  <link rel="shortcut icon" href="favicon.ico?v=2">
+  <link rel="icon" href="favicon.ico?v=2">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg?v=2">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="manifest" href="manifest.json">
+  <meta property="og:title" content="Page Not Found — Icarius Consulting" />
+  <meta property="og:description" content="The page you are looking for might have been moved." />
+  <meta property="og:image" content="og-image-brand.png" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Page Not Found — Icarius Consulting" />
+  <meta name="twitter:description" content="The page you are looking for might have been moved." />
+  <meta name="twitter:image" content="og-image-brand.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="chatbot.css">
+  <style>
+    body {
+      background: radial-gradient(circle at top, rgba(124, 92, 255, 0.16), transparent 55%), #070a12;
+      color: #ecf2ff;
+      font-family: 'Inter', sans-serif;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+
+    .error-wrapper {
+      max-width: 540px;
+      background: rgba(13, 20, 36, 0.8);
+      border-radius: 1.25rem;
+      padding: 2.5rem;
+      box-shadow: 0 24px 64px rgba(8, 14, 27, 0.55);
+      text-align: center;
+    }
+
+    .error-wrapper img {
+      height: 64px;
+      margin-bottom: 1.5rem;
+    }
+
+    .error-wrapper h1 {
+      font-size: 2.25rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .error-wrapper p {
+      color: #a5b4d5;
+      font-size: 1rem;
+      margin-bottom: 1.75rem;
+    }
+
+    .error-wrapper a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.85rem 1.75rem;
+      border-radius: 9999px;
+      background: #6366f1;
+      color: #fff;
+      font-weight: 600;
+      text-decoration: none;
+    }
+
+    .error-wrapper a:hover,
+    .error-wrapper a:focus-visible {
+      background: #4f46e5;
+    }
+  </style>
+</head>
+<body>
+  <div class="error-wrapper">
+    <img src="icarius-logo.svg" alt="Icarius Consulting" />
+    <h1>Page not found</h1>
+    <p>The page you are trying to reach doesn’t exist or may have moved. Let’s get you back on track.</p>
+    <a href="index.html">Return home</a>
+  </div>
+
+  <button class="chatbot-toggle" type="button" aria-expanded="false" aria-controls="chatbot-panel" aria-label="Open Icarius chatbot">
+    💬
+  </button>
+  <div class="chatbot-panel" id="chatbot-panel" hidden role="dialog" aria-modal="true" aria-labelledby="chatbot-title">
+    <div class="chatbot-header">
+      <h2 id="chatbot-title">Icarius Assistant</h2>
+      <button class="chatbot-close" type="button" data-chatbot-close aria-label="Close chatbot">&times;</button>
+    </div>
+    <div class="chatbot-body">
+      <div class="chatbot-messages" data-chatbot-messages role="log" aria-live="polite"></div>
+      <div class="chatbot-quick-replies">
+        <button type="button" data-chatbot-reply="overview">What does Icarius do?</button>
+        <button type="button" data-chatbot-reply="services">Which services do you offer?</button>
+        <button type="button" data-chatbot-reply="process">How does engagement work?</button>
+      </div>
+    </div>
+    <form class="chatbot-form" novalidate>
+      <p class="chatbot-status" data-chatbot-status role="status" aria-live="polite"></p>
+      <label for="chatbot-name">Name</label>
+      <input id="chatbot-name" name="name" type="text" autocomplete="name" required />
+      <label for="chatbot-email">Email</label>
+      <input id="chatbot-email" name="email" type="email" autocomplete="email" required />
+      <label for="chatbot-company">Company (optional)</label>
+      <input id="chatbot-company" name="company" type="text" autocomplete="organization" />
+      <label for="chatbot-message">How can we help?</label>
+      <textarea id="chatbot-message" name="message" rows="3" required></textarea>
+      <button type="submit">
+        <span>Send to Icarius</span>
+        <span class="chatbot-spinner" data-chatbot-spinner aria-hidden="true"></span>
+      </button>
+    </form>
+  </div>
+  <script src="chatbot.js" defer></script>
+</body>
+</html>

--- a/about.html
+++ b/about.html
@@ -27,6 +27,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
+  <link rel="stylesheet" href="chatbot.css">
+
   <style>
     :root {
       --bg: #070a12;
@@ -287,5 +289,39 @@
       <p>&copy; 2024 Icarius Consulting. All rights reserved.</p>
     </div>
   </footer>
+
+  <button class="chatbot-toggle" type="button" aria-expanded="false" aria-controls="chatbot-panel" aria-label="Open Icarius chatbot">
+    💬
+  </button>
+  <div class="chatbot-panel" id="chatbot-panel" hidden role="dialog" aria-modal="true" aria-labelledby="chatbot-title">
+    <div class="chatbot-header">
+      <h2 id="chatbot-title">Icarius Assistant</h2>
+      <button class="chatbot-close" type="button" data-chatbot-close aria-label="Close chatbot">&times;</button>
+    </div>
+    <div class="chatbot-body">
+      <div class="chatbot-messages" data-chatbot-messages role="log" aria-live="polite"></div>
+      <div class="chatbot-quick-replies">
+        <button type="button" data-chatbot-reply="overview">What does Icarius do?</button>
+        <button type="button" data-chatbot-reply="services">Which services do you offer?</button>
+        <button type="button" data-chatbot-reply="process">How does engagement work?</button>
+      </div>
+    </div>
+    <form class="chatbot-form" novalidate>
+      <p class="chatbot-status" data-chatbot-status role="status" aria-live="polite"></p>
+      <label for="chatbot-name">Name</label>
+      <input id="chatbot-name" name="name" type="text" autocomplete="name" required />
+      <label for="chatbot-email">Email</label>
+      <input id="chatbot-email" name="email" type="email" autocomplete="email" required />
+      <label for="chatbot-company">Company (optional)</label>
+      <input id="chatbot-company" name="company" type="text" autocomplete="organization" />
+      <label for="chatbot-message">How can we help?</label>
+      <textarea id="chatbot-message" name="message" rows="3" required></textarea>
+      <button type="submit">
+        <span>Send to Icarius</span>
+        <span class="chatbot-spinner" data-chatbot-spinner aria-hidden="true"></span>
+      </button>
+    </form>
+  </div>
+  <script src="chatbot.js" defer></script>
 </body>
 </html>

--- a/api/save-chat-request.js
+++ b/api/save-chat-request.js
@@ -1,0 +1,96 @@
+const { promises: fs } = require("fs");
+const path = require("path");
+
+const respond = (res, status, payload) => {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(payload));
+};
+
+const sanitize = (value) =>
+  String(value || "")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .replace(/[<>]/g, "")
+    .trim();
+
+const validatePayload = ({ name, email, company, message }) => {
+  const errors = [];
+  if (!name) errors.push("Name is required.");
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(email)) errors.push("A valid email is required.");
+  if (!message || message.length < 10) errors.push("Message should include at least 10 characters.");
+  if (company.length > 120) errors.push("Company name is too long.");
+  return errors;
+};
+
+const persistRequest = async (entry) => {
+  const directory = path.join("/tmp", "chatbot");
+  const filePath = path.join(directory, "requests.json");
+  await fs.mkdir(directory, { recursive: true });
+
+  try {
+    const file = await fs.readFile(filePath, "utf8");
+    const parsed = JSON.parse(file);
+    parsed.push(entry);
+    await fs.writeFile(filePath, JSON.stringify(parsed, null, 2), "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      await fs.writeFile(filePath, JSON.stringify([entry], null, 2), "utf8");
+    } else {
+      throw error;
+    }
+  }
+};
+
+module.exports = async function handler(req, res) {
+  if (req.method === "OPTIONS") {
+    res.setHeader("Allow", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.statusCode = 204;
+    return res.end();
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST, OPTIONS");
+    return respond(res, 405, { success: false, error: "Method not allowed." });
+  }
+
+  try {
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+    const rawBody = Buffer.concat(chunks).toString("utf8");
+    let parsedBody = {};
+    if (rawBody) {
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch (error) {
+        return respond(res, 400, { success: false, error: "Invalid JSON payload." });
+      }
+    }
+
+    const payload = {
+      name: sanitize(parsedBody.name),
+      email: sanitize(parsedBody.email),
+      company: sanitize(parsedBody.company),
+      message: sanitize(parsedBody.message),
+      submittedAt: new Date().toISOString(),
+      source: sanitize(req.headers["referer"]) || "website",
+      ip: sanitize(req.headers["x-forwarded-for"] || req.socket.remoteAddress || ""),
+    };
+
+    const errors = validatePayload(payload);
+    if (errors.length) {
+      return respond(res, 400, { success: false, error: errors.join(" ") });
+    }
+
+    await persistRequest(payload);
+
+    return respond(res, 200, { success: true });
+  } catch (error) {
+    console.error("Chatbot request failed", error);
+    return respond(res, 500, { success: false, error: "Unable to save request." });
+  }
+};

--- a/chatbot.css
+++ b/chatbot.css
@@ -1,0 +1,241 @@
+/* Chatbot widget shared styles */
+:root {
+  --chatbot-primary: #1f2937;
+  --chatbot-accent: #6366f1;
+  --chatbot-surface: #ffffff;
+  --chatbot-border: rgba(31, 41, 55, 0.12);
+  --chatbot-shadow: 0 12px 40px rgba(15, 23, 42, 0.22);
+}
+
+.chatbot-toggle {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 9999px;
+  border: none;
+  background: var(--chatbot-accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  cursor: pointer;
+  box-shadow: var(--chatbot-shadow);
+  z-index: 6000;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chatbot-toggle:focus-visible {
+  outline: 3px solid rgba(99, 102, 241, 0.5);
+  outline-offset: 3px;
+}
+
+.chatbot-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.28);
+}
+
+.chatbot-panel {
+  position: fixed;
+  bottom: 6.5rem;
+  right: 1.5rem;
+  width: min(360px, calc(100vw - 3rem));
+  max-height: min(540px, calc(100vh - 8rem));
+  background: var(--chatbot-surface);
+  border-radius: 1rem;
+  box-shadow: var(--chatbot-shadow);
+  border: 1px solid var(--chatbot-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 6000;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+}
+
+.chatbot-panel.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.chatbot-header {
+  padding: 1rem 1.25rem;
+  background: linear-gradient(90deg, #312e81, #6366f1);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chatbot-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.chatbot-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.chatbot-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: #f9fafb;
+}
+
+.chatbot-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chatbot-message {
+  max-width: 85%;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  line-height: 1.4;
+  font-size: 0.9375rem;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.1);
+}
+
+.chatbot-message.bot {
+  align-self: flex-start;
+  background: #ffffff;
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.chatbot-message.user {
+  align-self: flex-end;
+  background: #6366f1;
+  color: #fff;
+}
+
+.chatbot-quick-replies {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chatbot-quick-replies button {
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: #eef2ff;
+  color: #312e81;
+  border-radius: 9999px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.chatbot-quick-replies button:hover,
+.chatbot-quick-replies button:focus-visible {
+  background: #c7d2fe;
+  outline: none;
+}
+
+.chatbot-form {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--chatbot-border);
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chatbot-form label {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.chatbot-form input,
+.chatbot-form textarea {
+  width: 100%;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.8);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease;
+}
+
+.chatbot-form input:focus,
+.chatbot-form textarea:focus {
+  border-color: #6366f1;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.chatbot-form button[type="submit"] {
+  background: #1f2937;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.chatbot-form button[type="submit"]:hover,
+.chatbot-form button[type="submit"]:focus-visible {
+  background: #111827;
+}
+
+.chatbot-status {
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+  color: #1f2937;
+}
+
+.chatbot-status.error {
+  color: #dc2626;
+}
+
+.chatbot-status.success {
+  color: #047857;
+}
+
+.chatbot-spinner {
+  display: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(99, 102, 241, 0.3);
+  border-top-color: #6366f1;
+  border-radius: 50%;
+  animation: chatbot-spin 0.9s linear infinite;
+}
+
+.chatbot-spinner.visible {
+  display: inline-block;
+}
+
+@keyframes chatbot-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .chatbot-panel {
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+    bottom: 5.5rem;
+  }
+
+  .chatbot-toggle {
+    right: 1rem;
+    bottom: 1rem;
+  }
+}

--- a/chatbot.js
+++ b/chatbot.js
@@ -1,0 +1,154 @@
+(function () {
+  const sanitize = (value) =>
+    String(value || "")
+      .replace(/[\u0000-\u001F\u007F]/g, "")
+      .replace(/[<>]/g, "");
+
+  const cannedResponses = {
+    overview:
+      "Icarius Consulting helps growth-minded companies build marketing systems that align brand, content, and go-to-market execution.",
+    services:
+      "We support strategy sprints, messaging playbooks, RevOps advisory, and enablement to keep revenue teams in sync.",
+    process:
+      "Kick off with a discovery call, partner on focused roadmaps, then iterate with measurable experiments and continuous feedback.",
+  };
+
+  const togglePanel = (panel, toggles, expanded) => {
+    if (!panel) return;
+    const isOpen = expanded ?? !panel.classList.contains("open");
+    panel.classList.toggle("open", isOpen);
+    panel.toggleAttribute("hidden", !isOpen);
+    toggles.forEach((btn) => btn.setAttribute("aria-expanded", String(isOpen)));
+    if (isOpen) {
+      panel.querySelector("input, textarea")?.focus({ preventScroll: true });
+    } else {
+      toggles[0]?.focus({ preventScroll: true });
+    }
+  };
+
+  const appendMessage = (container, text, author) => {
+    if (!container) return;
+    const message = document.createElement("div");
+    message.className = `chatbot-message ${author}`;
+    message.textContent = text;
+    container.appendChild(message);
+    container.scrollTop = container.scrollHeight;
+  };
+
+  const resetForm = (form) => {
+    form.reset();
+    const firstInput = form.querySelector("input, textarea");
+    firstInput?.focus({ preventScroll: true });
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const panel = document.querySelector(".chatbot-panel");
+    const toggles = Array.from(document.querySelectorAll(".chatbot-toggle"));
+    if (!panel || toggles.length === 0) return;
+
+    const closeButton = panel.querySelector("[data-chatbot-close]");
+    const messages = panel.querySelector("[data-chatbot-messages]");
+    const quickReplyButtons = panel.querySelectorAll("[data-chatbot-reply]");
+    const form = panel.querySelector("form");
+    const status = panel.querySelector("[data-chatbot-status]");
+    const spinner = panel.querySelector("[data-chatbot-spinner]");
+
+    toggles.forEach((toggle) => {
+      toggle.addEventListener("click", () => togglePanel(panel, toggles));
+    });
+
+    closeButton?.addEventListener("click", () => togglePanel(panel, toggles, false));
+
+    appendMessage(
+      messages,
+      "Hi there! I’m the Icarius assistant. Ask me about our services or leave a note and we’ll follow up.",
+      "bot"
+    );
+
+    quickReplyButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const key = button.getAttribute("data-chatbot-reply");
+        const response = cannedResponses[key];
+        if (!response) return;
+        appendMessage(messages, button.textContent.trim(), "user");
+        window.setTimeout(() => {
+          appendMessage(messages, response, "bot");
+        }, 300);
+      });
+    });
+
+    const setStatus = (message, tone = "") => {
+      if (!status) return;
+      status.textContent = message;
+      status.classList.remove("error", "success");
+      if (tone) status.classList.add(tone);
+    };
+
+    const setSubmitting = (submitting) => {
+      if (!form) return;
+      Array.from(form.elements).forEach((element) => {
+        if ("disabled" in element) {
+          element.disabled = submitting;
+        }
+      });
+      if (spinner) {
+        spinner.classList.toggle("visible", submitting);
+      }
+    };
+
+    form?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!form) return;
+
+      const formData = new FormData(form);
+      const name = sanitize(formData.get("name"));
+      const email = sanitize(formData.get("email"));
+      const company = sanitize(formData.get("company"));
+      const message = sanitize(formData.get("message"));
+
+      const errors = [];
+      if (!name) errors.push("Please share your name.");
+      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailPattern.test(email)) errors.push("Enter a valid email address.");
+      if (!message || message.length < 10) errors.push("Tell us a bit more so we can help.");
+
+      if (errors.length) {
+        setStatus(errors.join(" "), "error");
+        return;
+      }
+
+      setStatus("Sending your note...");
+      setSubmitting(true);
+
+      try {
+        const response = await fetch("/api/save-chat-request", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name, email, company, message }),
+          credentials: "same-origin",
+        });
+
+        const payload = await response.json().catch(() => ({ success: false }));
+        if (!response.ok || !payload.success) {
+          const detail = payload.error || "We couldn’t send that. Please try again.";
+          throw new Error(detail);
+        }
+
+        appendMessage(
+          messages,
+          "Thanks for reaching out! A consultant will respond soon via email.",
+          "bot"
+        );
+        setStatus("Message sent successfully.", "success");
+        resetForm(form);
+      } catch (error) {
+        console.error("Chatbot submission failed", error);
+        setStatus(error.message || "We couldn’t send that. Please try again.", "error");
+      } finally {
+        setSubmitting(false);
+      }
+    });
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet"/>
+  <link rel="stylesheet" href="chatbot.css">
 
   <style>
     :root {
@@ -377,6 +378,39 @@
     </div>
   </footer>
 
+  <button class="chatbot-toggle" type="button" aria-expanded="false" aria-controls="chatbot-panel" aria-label="Open Icarius chatbot">
+    💬
+  </button>
+  <div class="chatbot-panel" id="chatbot-panel" hidden role="dialog" aria-modal="true" aria-labelledby="chatbot-title">
+    <div class="chatbot-header">
+      <h2 id="chatbot-title">Icarius Assistant</h2>
+      <button class="chatbot-close" type="button" data-chatbot-close aria-label="Close chatbot">&times;</button>
+    </div>
+    <div class="chatbot-body">
+      <div class="chatbot-messages" data-chatbot-messages role="log" aria-live="polite"></div>
+      <div class="chatbot-quick-replies">
+        <button type="button" data-chatbot-reply="overview">What does Icarius do?</button>
+        <button type="button" data-chatbot-reply="services">Which services do you offer?</button>
+        <button type="button" data-chatbot-reply="process">How does engagement work?</button>
+      </div>
+    </div>
+    <form class="chatbot-form" novalidate>
+      <p class="chatbot-status" data-chatbot-status role="status" aria-live="polite"></p>
+      <label for="chatbot-name">Name</label>
+      <input id="chatbot-name" name="name" type="text" autocomplete="name" required />
+      <label for="chatbot-email">Email</label>
+      <input id="chatbot-email" name="email" type="email" autocomplete="email" required />
+      <label for="chatbot-company">Company (optional)</label>
+      <input id="chatbot-company" name="company" type="text" autocomplete="organization" />
+      <label for="chatbot-message">How can we help?</label>
+      <textarea id="chatbot-message" name="message" rows="3" required></textarea>
+      <button type="submit">
+        <span>Send to Icarius</span>
+        <span class="chatbot-spinner" data-chatbot-spinner aria-hidden="true"></span>
+      </button>
+    </form>
+  </div>
+  <script src="chatbot.js" defer></script>
   <script src="https://assets.calendly.com/assets/external/widget.js"></script>
 </body>
 </html>

--- a/packages.html
+++ b/packages.html
@@ -27,6 +27,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
+  <link rel="stylesheet" href="chatbot.css">
+
   <style>
     :root {
       --bg: #070a12;
@@ -360,5 +362,39 @@
       <p>&copy; 2024 Icarius Consulting. All rights reserved.</p>
     </div>
   </footer>
+
+  <button class="chatbot-toggle" type="button" aria-expanded="false" aria-controls="chatbot-panel" aria-label="Open Icarius chatbot">
+    💬
+  </button>
+  <div class="chatbot-panel" id="chatbot-panel" hidden role="dialog" aria-modal="true" aria-labelledby="chatbot-title">
+    <div class="chatbot-header">
+      <h2 id="chatbot-title">Icarius Assistant</h2>
+      <button class="chatbot-close" type="button" data-chatbot-close aria-label="Close chatbot">&times;</button>
+    </div>
+    <div class="chatbot-body">
+      <div class="chatbot-messages" data-chatbot-messages role="log" aria-live="polite"></div>
+      <div class="chatbot-quick-replies">
+        <button type="button" data-chatbot-reply="overview">What does Icarius do?</button>
+        <button type="button" data-chatbot-reply="services">Which services do you offer?</button>
+        <button type="button" data-chatbot-reply="process">How does engagement work?</button>
+      </div>
+    </div>
+    <form class="chatbot-form" novalidate>
+      <p class="chatbot-status" data-chatbot-status role="status" aria-live="polite"></p>
+      <label for="chatbot-name">Name</label>
+      <input id="chatbot-name" name="name" type="text" autocomplete="name" required />
+      <label for="chatbot-email">Email</label>
+      <input id="chatbot-email" name="email" type="email" autocomplete="email" required />
+      <label for="chatbot-company">Company (optional)</label>
+      <input id="chatbot-company" name="company" type="text" autocomplete="organization" />
+      <label for="chatbot-message">How can we help?</label>
+      <textarea id="chatbot-message" name="message" rows="3" required></textarea>
+      <button type="submit">
+        <span>Send to Icarius</span>
+        <span class="chatbot-spinner" data-chatbot-spinner aria-hidden="true"></span>
+      </button>
+    </form>
+  </div>
+  <script src="chatbot.js" defer></script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -25,6 +25,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="chatbot.css">
 
   <style>
     :root {
@@ -242,6 +243,39 @@
     <div class="container">&copy; <span id="year"></span> Icarius Consulting. All rights reserved.</div>
   </footer>
 
+  <button class="chatbot-toggle" type="button" aria-expanded="false" aria-controls="chatbot-panel" aria-label="Open Icarius chatbot">
+    💬
+  </button>
+  <div class="chatbot-panel" id="chatbot-panel" hidden role="dialog" aria-modal="true" aria-labelledby="chatbot-title">
+    <div class="chatbot-header">
+      <h2 id="chatbot-title">Icarius Assistant</h2>
+      <button class="chatbot-close" type="button" data-chatbot-close aria-label="Close chatbot">&times;</button>
+    </div>
+    <div class="chatbot-body">
+      <div class="chatbot-messages" data-chatbot-messages role="log" aria-live="polite"></div>
+      <div class="chatbot-quick-replies">
+        <button type="button" data-chatbot-reply="overview">What does Icarius do?</button>
+        <button type="button" data-chatbot-reply="services">Which services do you offer?</button>
+        <button type="button" data-chatbot-reply="process">How does engagement work?</button>
+      </div>
+    </div>
+    <form class="chatbot-form" novalidate>
+      <p class="chatbot-status" data-chatbot-status role="status" aria-live="polite"></p>
+      <label for="chatbot-name">Name</label>
+      <input id="chatbot-name" name="name" type="text" autocomplete="name" required />
+      <label for="chatbot-email">Email</label>
+      <input id="chatbot-email" name="email" type="email" autocomplete="email" required />
+      <label for="chatbot-company">Company (optional)</label>
+      <input id="chatbot-company" name="company" type="text" autocomplete="organization" />
+      <label for="chatbot-message">How can we help?</label>
+      <textarea id="chatbot-message" name="message" rows="3" required></textarea>
+      <button type="submit">
+        <span>Send to Icarius</span>
+        <span class="chatbot-spinner" data-chatbot-spinner aria-hidden="true"></span>
+      </button>
+    </form>
+  </div>
+  <script src="chatbot.js" defer></script>
   <script>
     const yearEl = document.getElementById('year');
     if (yearEl) {

--- a/work.html
+++ b/work.html
@@ -27,6 +27,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
+  <link rel="stylesheet" href="chatbot.css">
+
   <style>
     :root {
       --bg: #070a12;
@@ -379,5 +381,39 @@
       <p>&copy; 2024 Icarius Consulting. All rights reserved.</p>
     </div>
   </footer>
+
+  <button class="chatbot-toggle" type="button" aria-expanded="false" aria-controls="chatbot-panel" aria-label="Open Icarius chatbot">
+    💬
+  </button>
+  <div class="chatbot-panel" id="chatbot-panel" hidden role="dialog" aria-modal="true" aria-labelledby="chatbot-title">
+    <div class="chatbot-header">
+      <h2 id="chatbot-title">Icarius Assistant</h2>
+      <button class="chatbot-close" type="button" data-chatbot-close aria-label="Close chatbot">&times;</button>
+    </div>
+    <div class="chatbot-body">
+      <div class="chatbot-messages" data-chatbot-messages role="log" aria-live="polite"></div>
+      <div class="chatbot-quick-replies">
+        <button type="button" data-chatbot-reply="overview">What does Icarius do?</button>
+        <button type="button" data-chatbot-reply="services">Which services do you offer?</button>
+        <button type="button" data-chatbot-reply="process">How does engagement work?</button>
+      </div>
+    </div>
+    <form class="chatbot-form" novalidate>
+      <p class="chatbot-status" data-chatbot-status role="status" aria-live="polite"></p>
+      <label for="chatbot-name">Name</label>
+      <input id="chatbot-name" name="name" type="text" autocomplete="name" required />
+      <label for="chatbot-email">Email</label>
+      <input id="chatbot-email" name="email" type="email" autocomplete="email" required />
+      <label for="chatbot-company">Company (optional)</label>
+      <input id="chatbot-company" name="company" type="text" autocomplete="organization" />
+      <label for="chatbot-message">How can we help?</label>
+      <textarea id="chatbot-message" name="message" rows="3" required></textarea>
+      <button type="submit">
+        <span>Send to Icarius</span>
+        <span class="chatbot-spinner" data-chatbot-spinner aria-hidden="true"></span>
+      </button>
+    </form>
+  </div>
+  <script src="chatbot.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared chatbot interface with quick replies and contact form placeholders across the site
- create reusable chatbot styling, scripting, and submission workflow that posts to a same-origin API
- implement a Vercel serverless function that validates and stores chat requests within the deployment environment

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9b6ad2b248330973c6fc27fb8dee4