### PR TITLE
Align 404 page with site layout and navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,88 +4,192 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Page Not Found — Icarius Consulting</title>
-  <link rel="shortcut icon" href="favicon.ico?v=2">
-  <link rel="icon" href="favicon.ico?v=2">
-  <link rel="icon" type="image/svg+xml" href="favicon.svg?v=2">
-  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-  <link rel="manifest" href="manifest.json">
+
+  <!-- Icons (root-relative for multi-level paths) -->
+  <link rel="shortcut icon" href="/favicon.ico?v=2">
+  <link rel="icon" href="/favicon.ico?v=2">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+
+  <!-- PWA -->
+  <link rel="manifest" href="/manifest.json">
+
+  <!-- Social previews -->
   <meta property="og:title" content="Page Not Found — Icarius Consulting" />
-  <meta property="og:description" content="The page you are looking for might have been moved." />
-  <meta property="og:image" content="og-image-brand.png" />
+  <meta property="og:description" content="The page you requested could not be found." />
+  <meta property="og:image" content="/og-image-brand.png" />
   <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://icarius-consulting.com/404" />
+
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Page Not Found — Icarius Consulting" />
-  <meta name="twitter:description" content="The page you are looking for might have been moved." />
-  <meta name="twitter:image" content="og-image-brand.png" />
+  <meta name="twitter:description" content="The page you requested could not be found." />
+  <meta name="twitter:image" content="/og-image-brand.png" />
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css">
-  <link rel="stylesheet" href="chatbot.css">
+  <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet"/>
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/chatbot.css">
+
   <style>
-    body {
-      background: radial-gradient(circle at top, rgba(124, 92, 255, 0.16), transparent 55%), #070a12;
-      color: #ecf2ff;
-      font-family: 'Inter', sans-serif;
-      margin: 0;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 2rem;
+    main {
+      padding: clamp(160px, 18vh, 220px) 0 120px;
     }
 
-    .error-wrapper {
-      max-width: 540px;
-      background: rgba(13, 20, 36, 0.8);
-      border-radius: 1.25rem;
-      padding: 2.5rem;
-      box-shadow: 0 24px 64px rgba(8, 14, 27, 0.55);
+    .error-section {
+      display: grid;
+      justify-items: center;
       text-align: center;
+      gap: 28px;
+      padding: clamp(48px, 8vw, 72px);
+      border-radius: 28px;
+      background: linear-gradient(160deg, rgba(15, 20, 36, 0.92), rgba(17, 27, 48, 0.88));
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 24px 64px rgba(8, 14, 27, 0.55);
     }
 
-    .error-wrapper img {
-      height: 64px;
-      margin-bottom: 1.5rem;
+    .error-section img {
+      width: 80px;
+      height: auto;
     }
 
-    .error-wrapper h1 {
-      font-size: 2.25rem;
-      margin-bottom: 0.75rem;
-    }
-
-    .error-wrapper p {
-      color: #a5b4d5;
-      font-size: 1rem;
-      margin-bottom: 1.75rem;
-    }
-
-    .error-wrapper a {
+    .error-eyebrow {
       display: inline-flex;
       align-items: center;
+      gap: 10px;
+      padding: 8px 18px;
+      border-radius: 999px;
+      background: rgba(124, 92, 255, 0.14);
+      color: #7c5cff;
+      font-weight: 600;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+    }
+
+    .error-section h1 {
+      margin: 0;
+      font-size: clamp(2.3rem, 4vw, 3rem);
+      line-height: 1.15;
+    }
+
+    .error-section p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 520px;
+    }
+
+    .error-actions {
+      display: flex;
+      flex-wrap: wrap;
       justify-content: center;
-      gap: 0.5rem;
-      padding: 0.85rem 1.75rem;
-      border-radius: 9999px;
+      gap: 14px;
+    }
+
+    .error-actions a {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 22px;
+      border-radius: 999px;
       background: #6366f1;
       color: #fff;
       font-weight: 600;
       text-decoration: none;
+      transition: background 0.25s ease;
     }
 
-    .error-wrapper a:hover,
-    .error-wrapper a:focus-visible {
+    .error-actions a.secondary {
+      background: rgba(124, 92, 255, 0.18);
+      color: var(--text);
+    }
+
+    .error-actions a:hover,
+    .error-actions a:focus-visible {
       background: #4f46e5;
+    }
+
+    .error-actions a.secondary:hover,
+    .error-actions a.secondary:focus-visible {
+      background: rgba(124, 92, 255, 0.28);
+    }
+
+    .error-links {
+      display: grid;
+      gap: 12px;
+      justify-items: center;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      font-weight: 500;
+      color: var(--muted);
+    }
+
+    .error-links a {
+      color: inherit;
+      text-decoration: underline;
+      text-decoration-color: rgba(149, 168, 197, 0.4);
+      text-decoration-thickness: 2px;
+    }
+
+    .error-links a:hover,
+    .error-links a:focus-visible {
+      color: var(--text);
+      text-decoration-color: currentColor;
+    }
+
+    @media (max-width: 640px) {
+      header nav {
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+
+      .error-section {
+        padding: 40px 32px;
+      }
+
+      .error-actions {
+        flex-direction: column;
+      }
     }
   </style>
 </head>
 <body>
-  <div class="error-wrapper">
-    <img src="icarius-logo.svg" alt="Icarius Consulting" />
-    <h1>Page not found</h1>
-    <p>The page you are trying to reach doesn’t exist or may have moved. Let’s get you back on track.</p>
-    <a href="index.html">Return home</a>
-  </div>
+  <header>
+    <div class="container nav">
+      <a class="logo-link" href="/">
+        <img src="/icarius-logo.svg" alt="Icarius Consulting logo" />
+        Icarius Consulting
+      </a>
+      <nav aria-label="Primary">
+        <a href="/services.html">Services</a>
+        <a href="/packages.html">Packages</a>
+        <a href="/work.html">Work</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="error-section container" aria-labelledby="error-title">
+      <span class="error-eyebrow">404 — Not found</span>
+      <img src="/icarius-logo.svg" alt="Icarius Consulting" />
+      <h1 id="error-title">We couldn’t find the page you were looking for.</h1>
+      <p>The link may be outdated or the page might have moved. Try one of the helpful links below to continue exploring Icarius Consulting.</p>
+      <div class="error-actions">
+        <a href="/">Return home</a>
+        <a class="secondary" href="/services.html">View our services</a>
+      </div>
+      <ul class="error-links" aria-label="Helpful Icarius links">
+        <li><a href="/work.html">See recent client work</a></li>
+        <li><a href="/packages.html">Compare engagement packages</a></li>
+        <li><a href="/contact.html">Start a conversation</a></li>
+      </ul>
+    </section>
+  </main>
 
   <button class="chatbot-toggle" type="button" aria-expanded="false" aria-controls="chatbot-panel" aria-label="Open Icarius chatbot">
     💬
@@ -119,6 +223,6 @@
       </button>
     </form>
   </div>
-  <script src="chatbot.js" defer></script>
+  <script src="/chatbot.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- align the 404 page head markup with the production assets, social previews, and font preloads used by the main site
- add the standard navigation header, Icarius branding, and contextual styling to keep the not-found page consistent with the rest of the experience
- provide clear 404 messaging with quick actions and helpful links back into the site while keeping chatbot support available

## Testing
- `python -m http.server 8000` (manual verification via local preview)
- `curl -s http://127.0.0.1:8000/404.html | head`
- `curl -s -o /tmp/deploy404.html -w "%{http_code}\n" https://icarius-consulting.com/nonexistent-page` *(fails in CI environment: upstream proxy returns 403 before reaching deployment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bc45e3f08330bf3a85abff2db941