### PR TITLE
Align navigation with clean URLs and legacy redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -164,11 +164,11 @@
         Icarius Consulting
       </a>
       <nav aria-label="Primary">
-        <a href="/services.html">Services</a>
-        <a href="/packages.html">Packages</a>
-        <a href="/work.html">Work</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
+        <a href="/services">Services</a>
+        <a href="/packages">Packages</a>
+        <a href="/work">Work</a>
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </header>
@@ -181,12 +181,12 @@
       <p>The link may be outdated or the page might have moved. Try one of the helpful links below to continue exploring Icarius Consulting.</p>
       <div class="error-actions">
         <a href="/">Return home</a>
-        <a class="secondary" href="/services.html">View our services</a>
+        <a class="secondary" href="/services">View our services</a>
       </div>
       <ul class="error-links" aria-label="Helpful Icarius links">
-        <li><a href="/work.html">See recent client work</a></li>
-        <li><a href="/packages.html">Compare engagement packages</a></li>
-        <li><a href="/contact.html">Start a conversation</a></li>
+        <li><a href="/work">See recent client work</a></li>
+        <li><a href="/packages">Compare engagement packages</a></li>
+        <li><a href="/contact">Start a conversation</a></li>
       </ul>
     </section>
   </main>

--- a/about.html
+++ b/about.html
@@ -27,17 +27,17 @@
 <body>
   <header>
     <div class="container nav">
-      <a class="logo-link" href="index.html">
+      <a class="logo-link" href="/">
         <img src="icarius-logo.svg" alt="Icarius" />
         Icarius
       </a>
       <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="about.html" aria-current="page">About</a>
-        <a href="services.html">Services</a>
-        <a href="work.html">Work</a>
-        <a href="packages.html">Packages</a>
-        <a href="contact.html">Contact</a>
+        <a href="/">Home</a>
+        <a href="/about" aria-current="page">About</a>
+        <a href="/services">Services</a>
+        <a href="/work">Work</a>
+        <a href="/packages">Packages</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </header>
@@ -144,7 +144,7 @@
         <h2>Let's talk about your HR roadmap</h2>
         <p>Email hello@icarius-consulting.com or book a discovery call.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="contact.html">Contact Icarius</a>
+          <a class="btn btn-primary" href="/contact">Contact Icarius</a>
         </div>
       </div>
     </section>
@@ -154,7 +154,7 @@
       <span class="tagline">© 2025 Icarius Consulting</span>
       <nav>
         <a href="/">Home</a>
-        <a href="/contact.html">Contact</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </footer>

--- a/contact.html
+++ b/contact.html
@@ -26,17 +26,17 @@
 <body>
   <header>
     <div class="container nav">
-      <a class="logo-link" href="index.html">
+      <a class="logo-link" href="/">
         <img src="icarius-logo.svg" alt="Icarius" />
         Icarius
       </a>
       <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="services.html">Services</a>
-        <a href="work.html">Work</a>
-        <a href="packages.html">Packages</a>
-        <a href="contact.html" aria-current="page">Contact</a>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/services">Services</a>
+        <a href="/work">Work</a>
+        <a href="/packages">Packages</a>
+        <a href="/contact" aria-current="page">Contact</a>
       </nav>
     </div>
   </header>
@@ -92,7 +92,7 @@
       <span class="tagline">© 2025 Icarius Consulting</span>
       <nav>
         <a href="/">Home</a>
-        <a href="/contact.html">Contact</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -88,15 +88,15 @@
         <span>Icarius Consulting</span>
       </a>
       <nav class="primary" aria-label="Primary">
-        <a href="/services.html">Services</a>
-        <a href="/work.html">Work</a>
-        <a href="/packages.html">Packages</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
+        <a href="/services">Services</a>
+        <a href="/work">Work</a>
+        <a href="/packages">Packages</a>
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
       </nav>
       <div class="actions">
-        <a class="btn btn-ghost" href="/packages.html">View Packages</a>
-        <a class="btn btn-primary" href="/contact.html">Get Started</a>
+        <a class="btn btn-ghost" href="/packages">View Packages</a>
+        <a class="btn btn-primary" href="/contact">Get Started</a>
       </div>
     </div>
   </header>
@@ -108,8 +108,8 @@
           <h1 class="headline">Build, Launch, and Grow — faster.</h1>
           <p class="sub">Strategy, design, and engineering services crafted for momentum. Taskade‑style focus with collaborative velocity. We turn ideas into shipped product.</p>
           <div class="cta-row">
-            <a class='btn btn-ghost' href='services.html'>Explore Services</a>
-            <a class="btn btn-primary" href="/work.html">See Our Work</a>
+            <a class='btn btn-ghost' href='/services'>Explore Services</a>
+            <a class="btn btn-primary" href="/work">See Our Work</a>
           </div>
           <div class="metrics" aria-label="Key outcomes">
             <div class="metric"><h4>3x faster</h4><p>Average time‑to‑launch improvement</p></div>
@@ -124,9 +124,9 @@
       <div class="container">
         <h2>Services that accelerate your roadmap</h2>
         <div class="services-grid">
-          <div class="card"><div class="pulse" aria-hidden="true"></div><h3>Product Strategy</h3><p>North‑star alignment, roadmaps, and OKRs that drive outcomes.</p><a class="btn btn-ghost" href="/services.html#strategy">Learn more</a></div>
-          <div class="card"><div class="pulse" aria-hidden="true"></div><h3>Design Systems</h3><p>Accessible, scalable UI libraries that ship with velocity.</p><a class="btn btn-ghost" href="/services.html#design">Learn more</a></div>
-          <div class="card"><div class="pulse" aria-hidden="true"></div><h3>Full‑stack Delivery</h3><p>From prototype to production with CI/CD and observability.</p><a class="btn btn-ghost" href="/services.html#engineering">Learn more</a></div>
+          <div class="card"><div class="pulse" aria-hidden="true"></div><h3>Product Strategy</h3><p>North‑star alignment, roadmaps, and OKRs that drive outcomes.</p><a class="btn btn-ghost" href="/services#strategy">Learn more</a></div>
+          <div class="card"><div class="pulse" aria-hidden="true"></div><h3>Design Systems</h3><p>Accessible, scalable UI libraries that ship with velocity.</p><a class="btn btn-ghost" href="/services#design">Learn more</a></div>
+          <div class="card"><div class="pulse" aria-hidden="true"></div><h3>Full‑stack Delivery</h3><p>From prototype to production with CI/CD and observability.</p><a class="btn btn-ghost" href="/services#engineering">Learn more</a></div>
         </div>
       </div>
     </section>
@@ -148,7 +148,7 @@ fetch('/packages.json')
             <li>Real‑time status chips and progress</li>
             <li>Auto‑synced docs and briefs</li>
           </ul>
-          <a class="btn btn-primary" href="/packages.html">Explore Packages</a>
+          <a class="btn btn-primary" href="/packages">Explore Packages</a>
         </div>
       </div>
     </section>
@@ -182,8 +182,8 @@ fetch('/packages.json')
       <nav aria-label="Footer">
         <a href="/sitemap.xml">Sitemap</a>
         <a href="/robots.txt">Robots</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </footer>

--- a/packages.html
+++ b/packages.html
@@ -104,17 +104,17 @@
   <body>
     <header>
       <div class="container nav">
-        <a class="logo-link" href="index.html">
+        <a class="logo-link" href="/">
           <img alt="Icarius"/>
           Icarius
         </a>
         <nav aria-label="Primary">
-          <a href="index.html">Home</a>
-          <a href="about.html">About</a>
-          <a href="services.html">Services</a>
-          <a href="work.html">Work</a>
-          <a aria-current="page" href="packages.html">Packages</a>
-          <a href="contact.html">Contact</a>
+          <a href="/">Home</a>
+          <a href="/about">About</a>
+          <a href="/services">Services</a>
+          <a href="/work">Work</a>
+          <a aria-current="page" href="/packages">Packages</a>
+          <a href="/contact">Contact</a>
         </nav>
       </div>
     </header>
@@ -153,7 +153,7 @@
         <span class="tagline">© 2025 Icarius Consulting</span>
         <nav>
           <a href="/">Home</a>
-          <a href="/contact.html">Contact</a>
+          <a href="/contact">Contact</a>
         </nav>
       </div>
     </footer>
@@ -231,7 +231,7 @@
                   ${(p.highlights||[]).map(h => `<li><span>✓</span>${h}</li>`).join('')}
                 </ul>
                 <div class="cta">
-                  <a class="btn btn-primary" href="contact.html">Start now</a>
+                  <a class="btn btn-primary" href="/contact">Start now</a>
                   <button class="btn btn-ghost learn-btn" type="button" data-learn data-inline="#${inlineId}">Learn more</button>
                 </div>
                 <div id="${inlineId}" class="inline-panel" hidden></div>
@@ -340,7 +340,7 @@
 
           const modal = document.getElementById('pkg-modal');
           function openModal(title, html){
-            modal.innerHTML = `<div class="modal-card"><h3 id="pkg-title">${title}</h3>${html}<div style="display:flex; gap:10px; margin-top:16px;"><button class="btn btn-primary" onclick="document.getElementById('pkg-modal').close()">Close</button><a class="btn btn-ghost" href="contact.html">Talk to us</a></div></div>`;
+            modal.innerHTML = `<div class="modal-card"><h3 id="pkg-title">${title}</h3>${html}<div style="display:flex; gap:10px; margin-top:16px;"><button class="btn btn-primary" onclick="document.getElementById('pkg-modal').close()">Close</button><a class="btn btn-ghost" href="/contact">Talk to us</a></div></div>`;
             if (!modal.open) modal.showModal();
           }
 

--- a/services.html
+++ b/services.html
@@ -27,17 +27,17 @@
 <body>
   <header>
     <div class="container nav">
-      <a class="logo-link" href="index.html">
+      <a class="logo-link" href="/">
         <img src="icarius-logo.svg" alt="Icarius" />
         Icarius
       </a>
       <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="services.html" aria-current="page">Services</a>
-        <a href="work.html">Work</a>
-        <a href="packages.html">Packages</a>
-        <a href="contact.html">Contact</a>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/services" aria-current="page">Services</a>
+        <a href="/work">Work</a>
+        <a href="/packages">Packages</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </header>
@@ -80,7 +80,7 @@
     <section class="container">
       <div class="contact-card">
         <h2>Ready to scope your engagement?</h2>
-        <p>Review the <a href="packages.html">packages catalogue</a> for sprint-based pricing, or <a href="contact.html">book a call</a> to create something bespoke.</p>
+        <p>Review the <a href="/packages">packages catalogue</a> for sprint-based pricing, or <a href="/contact">book a call</a> to create something bespoke.</p>
       </div>
     </section>
   </main>
@@ -89,7 +89,7 @@
       <span class="tagline">© 2025 Icarius Consulting</span>
       <nav>
         <a href="/">Home</a>
-        <a href="/contact.html">Contact</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </footer>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,13 @@
 {
   "cleanUrls": true,
+  "trailingSlash": false,
   "redirects": [
+    { "source": "/index.html", "destination": "/", "permanent": true },
+    { "source": "/about.html", "destination": "/about", "permanent": true },
+    { "source": "/services.html", "destination": "/services", "permanent": true },
+    { "source": "/work.html", "destination": "/work", "permanent": true },
+    { "source": "/packages.html", "destination": "/packages", "permanent": true },
+    { "source": "/contact.html", "destination": "/contact", "permanent": true },
     {
       "source": "/:path*",
       "has": [{ "type": "host", "value": "www.icarius-consulting.com" }],

--- a/work.html
+++ b/work.html
@@ -27,17 +27,17 @@
 <body>
   <header>
     <div class="container nav">
-      <a class="logo-link" href="index.html">
+      <a class="logo-link" href="/">
         <img src="icarius-logo.svg" alt="Icarius" />
         Icarius
       </a>
       <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="services.html">Services</a>
-        <a href="work.html" aria-current="page">Work</a>
-        <a href="packages.html">Packages</a>
-        <a href="contact.html">Contact</a>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/services">Services</a>
+        <a href="/work" aria-current="page">Work</a>
+        <a href="/packages">Packages</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </header>
@@ -119,7 +119,7 @@
         <h2>Ready to start?</h2>
         <p>Explore packages or request a custom scope.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="packages.html">View Packages</a>
+          <a class="btn btn-primary" href="/packages">View Packages</a>
         </div>
       </div>
     </section>
@@ -129,7 +129,7 @@
       <span class="tagline">© 2025 Icarius Consulting</span>
       <nav>
         <a href="/">Home</a>
-        <a href="/contact.html">Contact</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- add Vercel redirects for legacy .html routes and disable trailing slashes while keeping clean URLs enabled
- update navigation, footer, and CTA links across static pages to point at clean URL slugs

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68defa61ce708330b41944161aa5ce96