### PR TITLE
Add reusable booking CTA component and scheduler integration

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BOOKING_URL=https://calendly.com/icarius-consulting/introduction-call

--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ The site includes a manifest and icons so it can be installed as a Progressive W
 - Hosted on: [https://icarius-consulting.com](https://icarius-consulting.com)
 - Built with: **HTML5 + CSS3 (Inter font)**, no JS framework required.
 - Analytics, calendly, and form integrations can be added via embedded scripts.
+- Booking CTAs resolve the scheduler URL from `NEXT_PUBLIC_BOOKING_URL`. Provide this in `.env.local` for local previews and set the same value in Vercel Project Settings.

--- a/about.html
+++ b/about.html
@@ -142,9 +142,9 @@
     <section class="section">
       <div class="container">
         <h2>Let's talk about your HR roadmap</h2>
-        <p>Email hello@icarius-consulting.com or book a discovery call.</p>
+        <p>Email hello@icarius-consulting.com or <book-cta variant="inline" label="book a discovery call"></book-cta>.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="/contact">Contact Icarius</a>
+          <book-cta label="Book a discovery call"></book-cta>
         </div>
       </div>
     </section>
@@ -188,6 +188,7 @@
       </button>
     </form>
   </div>
+  <script defer src="/components/book-cta.js"></script>
   <script defer src="chatbot.js"></script>
 </body>
 </html>

--- a/api/booking-url.js
+++ b/api/booking-url.js
@@ -1,0 +1,12 @@
+module.exports = (req, res) => {
+  const bookingUrl = process.env.NEXT_PUBLIC_BOOKING_URL;
+
+  if (!bookingUrl) {
+    res.status(500).json({ error: 'Booking URL is not configured.' });
+    return;
+  }
+
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600');
+  res.setHeader('Content-Type', 'application/json');
+  res.status(200).json({ bookingUrl });
+};

--- a/components/book-cta.js
+++ b/components/book-cta.js
@@ -1,0 +1,102 @@
+(function(){
+  const CTA_VARIANTS = {
+    primary: 'btn btn-primary',
+    ghost: 'btn btn-ghost',
+    inline: 'cta-inline'
+  };
+
+  let bookingUrlPromise;
+
+  function getBookingUrl(){
+    if (typeof window !== 'undefined' && window.NEXT_PUBLIC_BOOKING_URL) {
+      return Promise.resolve(window.NEXT_PUBLIC_BOOKING_URL);
+    }
+    if (!bookingUrlPromise) {
+      bookingUrlPromise = fetch('/api/booking-url', { cache: 'no-store' })
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error('Unable to load booking URL');
+          }
+          return res.json();
+        })
+        .then((payload) => {
+          if (!payload || !payload.bookingUrl) {
+            throw new Error('Booking URL missing from payload');
+          }
+          return payload.bookingUrl;
+        })
+        .catch((error) => {
+          console.error('[BookCTA] Failed to resolve booking URL', error);
+          throw error;
+        });
+    }
+    return bookingUrlPromise;
+  }
+
+  function withPlan(url, plan){
+    if (!plan) return url;
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}plan=${encodeURIComponent(plan)}`;
+  }
+
+  class BookCTA extends HTMLElement {
+    static get observedAttributes(){
+      return ['label', 'variant', 'plan', 'target'];
+    }
+
+    constructor(){
+      super();
+      this._anchor = document.createElement('a');
+      this._anchor.setAttribute('rel', 'noopener noreferrer');
+      this._anchor.dataset.loading = 'true';
+      this.appendChild(this._anchor);
+    }
+
+    connectedCallback(){
+      this.update();
+    }
+
+    attributeChangedCallback(){
+      this.update();
+    }
+
+    update(){
+      const label = this.getAttribute('label') || 'Book a discovery call';
+      const variant = (this.getAttribute('variant') || 'primary').toLowerCase();
+      const plan = this.getAttribute('plan');
+      const target = this.getAttribute('target') || '_blank';
+
+      const classes = CTA_VARIANTS[variant] || CTA_VARIANTS.primary;
+      this._anchor.className = classes;
+      this._anchor.textContent = label;
+      this._anchor.setAttribute('target', target);
+
+      if (classes.includes('btn')) {
+        this._anchor.classList.add('btn');
+      }
+
+      this._anchor.setAttribute('aria-disabled', 'true');
+      this._anchor.removeAttribute('href');
+      this._anchor.dataset.loading = 'true';
+
+      getBookingUrl()
+        .then((baseUrl) => {
+          if (!this.isConnected) return;
+          const finalUrl = withPlan(baseUrl, plan);
+          this._anchor.setAttribute('href', finalUrl);
+          this._anchor.removeAttribute('aria-disabled');
+          this._anchor.dataset.loading = 'false';
+        })
+        .catch(() => {
+          if (!this.isConnected) return;
+          this._anchor.dataset.loading = 'error';
+          this._anchor.setAttribute('aria-disabled', 'true');
+          this._anchor.textContent = 'Booking unavailable';
+        });
+    }
+  }
+
+  if (!customElements.get('book-cta')) {
+    customElements.define('book-cta', BookCTA);
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
     .btn-primary { background: linear-gradient(90deg, var(--brand), var(--brand-2)); color:#0b1022; box-shadow: 0 8px 24px rgba(124,58,237,.35); }
     .btn-primary:hover { transform: translateY(-1px) scale(1.01); }
 
+    book-cta { display:inline-flex; }
+
     /* Actions container for CTA buttons */
     .actions { display: flex; gap: 12px; align-items: center; }
 
@@ -96,7 +98,7 @@
       </nav>
       <div class="actions">
         <a class="btn btn-ghost" href="/packages">View Packages</a>
-        <a class="btn btn-primary" href="/contact">Get Started</a>
+        <book-cta label="Book a discovery call"></book-cta>
       </div>
     </div>
   </header>
@@ -110,6 +112,7 @@
           <div class="cta-row">
             <a class='btn btn-ghost' href='/services'>Explore Services</a>
             <a class="btn btn-primary" href="/work">See Our Work</a>
+            <book-cta label="Book a call"></book-cta>
           </div>
           <div class="metrics" aria-label="Key outcomes">
             <div class="metric"><h4>3x faster</h4><p>Average time‑to‑launch improvement</p></div>
@@ -188,6 +191,7 @@ fetch('/packages.json')
     </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
+  <script src="/components/book-cta.js" defer></script>
   <script src="/chatbot.js" defer></script>
 </body>
 </html>

--- a/packages.html
+++ b/packages.html
@@ -45,6 +45,8 @@
       .feat li span { width: 22px; height: 22px; border-radius:50%; background: rgba(6,182,212,.15); color:#06b6d4; display:grid; place-items:center; font-size:.75rem; font-weight: 800; }
       .cta { margin-top: 8px; display:flex; gap:10px; }
       .cta .btn { flex:1; }
+      .price-card .cta book-cta { flex:1; display:flex; }
+      .price-card .cta book-cta .btn { width:100%; justify-content:center; }
       .note { text-align:center; margin-top: 14px; color: var(--muted); font-size: .9rem; }
       .learn-btn { position: relative; }
       
@@ -126,7 +128,7 @@
       </section>
       <section class="container">
         <div aria-live="polite" class="price-grid" id="price-grid"></div>
-        <p class="note">Need a custom plan or enterprise SOW? Contact us and we’ll tailor a package.</p>
+        <p class="note">Need a custom plan or enterprise SOW? <book-cta variant="inline" label="Book a discovery call"></book-cta> and we’ll tailor a package.</p>
       </section>
       <section class="container">
         <div class="grid-3">
@@ -161,6 +163,7 @@
   <div id="floating-ribbon" class="floating-ribbon" aria-hidden="true"><div class="pill">Most Popular</div></div>
   <dialog class="modal" id="pkg-modal" aria-labelledby="pkg-title" aria-modal="true"></dialog>
 
+    <script src="/components/book-cta.js" defer></script>
     <script>
       // Remove GBP mention only from hero/main copy if present
       (function(){
@@ -231,7 +234,7 @@
                   ${(p.highlights||[]).map(h => `<li><span>✓</span>${h}</li>`).join('')}
                 </ul>
                 <div class="cta">
-                  <a class="btn btn-primary" href="/contact">Start now</a>
+                  <book-cta label="Start now" plan="${key}"></book-cta>
                   <button class="btn btn-ghost learn-btn" type="button" data-learn data-inline="#${inlineId}">Learn more</button>
                 </div>
                 <div id="${inlineId}" class="inline-panel" hidden></div>
@@ -339,8 +342,9 @@
           });
 
           const modal = document.getElementById('pkg-modal');
-          function openModal(title, html){
-            modal.innerHTML = `<div class="modal-card"><h3 id="pkg-title">${title}</h3>${html}<div style="display:flex; gap:10px; margin-top:16px;"><button class="btn btn-primary" onclick="document.getElementById('pkg-modal').close()">Close</button><a class="btn btn-ghost" href="/contact">Talk to us</a></div></div>`;
+          function openModal(title, html, planKey){
+            const planAttr = planKey ? ` plan="${planKey}"` : '';
+            modal.innerHTML = `<div class="modal-card"><h3 id="pkg-title">${title}</h3>${html}<div style="display:flex; gap:10px; margin-top:16px;"><button class="btn btn-primary" onclick="document.getElementById('pkg-modal').close()">Close</button><book-cta variant="ghost" label="Talk to us"${planAttr}></book-cta></div></div>`;
             if (!modal.open) modal.showModal();
           }
 
@@ -358,9 +362,9 @@
             const key = card?.dataset.key;
             const panelSel = btn.getAttribute('data-inline');
             const panel = panelSel ? card.querySelector(panelSel) : null;
-            const pkg = packageExplainers[key] || { title: 'Package details', html: '<p>Contact us for a tailored scope.</p>' };
+            const pkg = packageExplainers[key] || { title: 'Package details', html: '<p><book-cta variant="inline" label="Book a discovery call"></book-cta> for a tailored scope.</p>' };
             if (panel) fillInline(panel, pkg.title, pkg.html);
-            openModal(pkg.title, pkg.html);
+            openModal(pkg.title, pkg.html, key);
           });
 
           // Hover to preview inline (no modal) after short delay
@@ -374,7 +378,7 @@
               const key = card?.dataset.key;
               const panelSel = btn.getAttribute('data-inline');
               const panel = panelSel ? card.querySelector(panelSel) : null;
-              const pkg = packageExplainers[key] || { title: 'Package details', html: '<p>Contact us for a tailored scope.</p>' };
+              const pkg = packageExplainers[key] || { title: 'Package details', html: '<p><book-cta variant="inline" label="Book a discovery call"></book-cta> for a tailored scope.</p>' };
               if (panel) fillInline(panel, pkg.title, pkg.html);
             }, 220);
           });
@@ -392,7 +396,5 @@
       // Initialize packages when DOM is loaded
       document.addEventListener('DOMContentLoaded', loadPackages);
     </script>
-  </body>
-</html>
   </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -80,7 +80,10 @@
     <section class="container">
       <div class="contact-card">
         <h2>Ready to scope your engagement?</h2>
-        <p>Review the <a href="/packages">packages catalogue</a> for sprint-based pricing, or <a href="/contact">book a call</a> to create something bespoke.</p>
+        <p>Review the <a href="/packages">packages catalogue</a> for sprint-based pricing, or <book-cta variant="inline" label="book a call"></book-cta> to create something bespoke.</p>
+        <div class="hero-actions">
+          <book-cta label="Book a discovery call"></book-cta>
+        </div>
       </div>
     </section>
   </main>
@@ -123,6 +126,7 @@
       </button>
     </form>
   </div>
+  <script defer src="/components/book-cta.js"></script>
   <script defer src="chatbot.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -221,6 +221,24 @@ p {
   transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
 }
 
+.cta-inline {
+  display: inline;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: rgba(255, 255, 255, 0.4);
+}
+
+.cta-inline:hover,
+.cta-inline:focus-visible {
+  color: var(--primary-2);
+}
+
+book-cta {
+  display: inline-flex;
+}
+
 .btn-primary {
   background: linear-gradient(180deg, var(--primary), #556ef6);
   color: #0a0f22;

--- a/work.html
+++ b/work.html
@@ -117,9 +117,10 @@
     <section class="container">
       <div class="contact-card">
         <h2>Ready to start?</h2>
-        <p>Explore packages or request a custom scope.</p>
+        <p>Explore packages or <book-cta variant="inline" label="book a discovery call"></book-cta> for a custom scope.</p>
         <div class="hero-actions">
           <a class="btn btn-primary" href="/packages">View Packages</a>
+          <book-cta label="Book a discovery call"></book-cta>
         </div>
       </div>
     </section>
@@ -163,6 +164,7 @@
       </button>
     </form>
   </div>
+  <script defer src="/components/book-cta.js"></script>
   <script defer src="chatbot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable `<book-cta>` component that resolves the shared scheduler URL from `NEXT_PUBLIC_BOOKING_URL`
- route hero, header, footer, and package CTAs through the new component with inline and button variants
- document the new booking environment variable for local and Vercel configuration

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68defb62b0548330af201541727eaa00