### PR TITLE
Add API-backed contact submission flow

### DIFF
--- a/404.html
+++ b/404.html
@@ -223,6 +223,6 @@
       </button>
     </form>
   </div>
-  <script src="/chatbot.js" defer></script>
+  <script type="module" src="/chatbot.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -189,6 +189,6 @@
     </form>
   </div>
   <script defer src="/components/book-cta.js"></script>
-  <script defer src="chatbot.js"></script>
+  <script type="module" src="chatbot.js"></script>
 </body>
 </html>

--- a/api/contact.js
+++ b/api/contact.js
@@ -1,0 +1,103 @@
+const respond = (res, status, payload) => {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(payload));
+};
+
+const sanitize = (value) =>
+  String(value ?? "")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .trim();
+
+const isValidEmail = (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+module.exports = async function handler(req, res) {
+  if (req.method === "OPTIONS") {
+    res.setHeader("Allow", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.statusCode = 204;
+    return res.end();
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST, OPTIONS");
+    return respond(res, 405, { ok: false, error: "Method not allowed." });
+  }
+
+  try {
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+    const rawBody = Buffer.concat(chunks).toString("utf8");
+
+    if (!rawBody) {
+      return respond(res, 400, { ok: false, error: "Missing request body." });
+    }
+
+    let parsedBody;
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch (error) {
+      return respond(res, 400, { ok: false, error: "Invalid JSON payload." });
+    }
+
+    const payload = {
+      name: sanitize(parsedBody.name),
+      email: sanitize(parsedBody.email),
+      message: sanitize(parsedBody.message),
+      company: sanitize(parsedBody.company),
+      source: sanitize(parsedBody.source || req.headers["referer"] || ""),
+    };
+
+    if (!payload.name) {
+      return respond(res, 400, { ok: false, error: "Name is required." });
+    }
+
+    if (!isValidEmail(payload.email)) {
+      return respond(res, 400, { ok: false, error: "A valid email address is required." });
+    }
+
+    if (!payload.message) {
+      return respond(res, 400, { ok: false, error: "Message is required." });
+    }
+
+    const webhookUrl = process.env.CONTACT_WEBHOOK_URL;
+    if (webhookUrl) {
+      try {
+        const response = await fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: payload.name,
+            email: payload.email,
+            message: payload.message,
+            company: payload.company,
+            source: payload.source,
+            submittedAt: new Date().toISOString(),
+          }),
+        });
+
+        if (!response.ok) {
+          const detail = await response.text().catch(() => "");
+          throw new Error(detail || `Webhook request failed with status ${response.status}.`);
+        }
+      } catch (error) {
+        console.error("Contact webhook request failed", error);
+        return respond(res, 502, {
+          ok: false,
+          error: "Unable to deliver the message.",
+        });
+      }
+    }
+
+    return respond(res, 200, { ok: true });
+  } catch (error) {
+    console.error("Contact form handler failed", error);
+    return respond(res, 500, {
+      ok: false,
+      error: "Unexpected error while submitting the form.",
+    });
+  }
+};

--- a/chatbot.js
+++ b/chatbot.js
@@ -1,154 +1,146 @@
-(function () {
-  const sanitize = (value) =>
-    String(value || "")
-      .replace(/[\u0000-\u001F\u007F]/g, "")
-      .replace(/[<>]/g, "");
+import {
+  sanitize,
+  submitContactRequest,
+  validateContactFields,
+} from "./components/contact-request.js";
 
-  const cannedResponses = {
-    overview:
-      "Icarius Consulting helps growth-minded companies build marketing systems that align brand, content, and go-to-market execution.",
-    services:
-      "We support strategy sprints, messaging playbooks, RevOps advisory, and enablement to keep revenue teams in sync.",
-    process:
-      "Kick off with a discovery call, partner on focused roadmaps, then iterate with measurable experiments and continuous feedback.",
+const cannedResponses = {
+  overview:
+    "Icarius Consulting helps growth-minded companies build marketing systems that align brand, content, and go-to-market execution.",
+  services:
+    "We support strategy sprints, messaging playbooks, RevOps advisory, and enablement to keep revenue teams in sync.",
+  process:
+    "Kick off with a discovery call, partner on focused roadmaps, then iterate with measurable experiments and continuous feedback.",
+};
+
+const togglePanel = (panel, toggles, expanded) => {
+  if (!panel) return;
+  const isOpen = expanded ?? !panel.classList.contains("open");
+  panel.classList.toggle("open", isOpen);
+  panel.toggleAttribute("hidden", !isOpen);
+  toggles.forEach((btn) => btn.setAttribute("aria-expanded", String(isOpen)));
+  if (isOpen) {
+    panel.querySelector("input, textarea")?.focus({ preventScroll: true });
+  } else {
+    toggles[0]?.focus({ preventScroll: true });
+  }
+};
+
+const appendMessage = (container, text, author) => {
+  if (!container) return;
+  const message = document.createElement("div");
+  message.className = `chatbot-message ${author}`;
+  message.textContent = text;
+  container.appendChild(message);
+  container.scrollTop = container.scrollHeight;
+};
+
+const resetForm = (form) => {
+  form.reset();
+  const firstInput = form.querySelector("input, textarea");
+  firstInput?.focus({ preventScroll: true });
+};
+
+const fieldMessages = {
+  name: "Please share your name.",
+  email: "Enter a valid email address.",
+  message: "Tell us a bit more so we can help.",
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  const panel = document.querySelector(".chatbot-panel");
+  const toggles = Array.from(document.querySelectorAll(".chatbot-toggle"));
+  if (!panel || toggles.length === 0) return;
+
+  const closeButton = panel.querySelector("[data-chatbot-close]");
+  const messages = panel.querySelector("[data-chatbot-messages]");
+  const quickReplyButtons = panel.querySelectorAll("[data-chatbot-reply]");
+  const form = panel.querySelector("form");
+  const status = panel.querySelector("[data-chatbot-status]");
+  const spinner = panel.querySelector("[data-chatbot-spinner]");
+
+  toggles.forEach((toggle) => {
+    toggle.addEventListener("click", () => togglePanel(panel, toggles));
+  });
+
+  closeButton?.addEventListener("click", () => togglePanel(panel, toggles, false));
+
+  appendMessage(
+    messages,
+    "Hi there! I’m the Icarius assistant. Ask me about our services or leave a note and we’ll follow up.",
+    "bot",
+  );
+
+  quickReplyButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const key = button.getAttribute("data-chatbot-reply");
+      const response = cannedResponses[key];
+      if (!response) return;
+      appendMessage(messages, button.textContent.trim(), "user");
+      window.setTimeout(() => {
+        appendMessage(messages, response, "bot");
+      }, 300);
+    });
+  });
+
+  const setStatus = (message, tone = "") => {
+    if (!status) return;
+    status.textContent = message;
+    status.classList.remove("error", "success");
+    if (tone) status.classList.add(tone);
   };
 
-  const togglePanel = (panel, toggles, expanded) => {
-    if (!panel) return;
-    const isOpen = expanded ?? !panel.classList.contains("open");
-    panel.classList.toggle("open", isOpen);
-    panel.toggleAttribute("hidden", !isOpen);
-    toggles.forEach((btn) => btn.setAttribute("aria-expanded", String(isOpen)));
-    if (isOpen) {
-      panel.querySelector("input, textarea")?.focus({ preventScroll: true });
-    } else {
-      toggles[0]?.focus({ preventScroll: true });
+  const setSubmitting = (submitting) => {
+    if (!form) return;
+    Array.from(form.elements).forEach((element) => {
+      if ("disabled" in element) {
+        element.disabled = submitting;
+      }
+    });
+    if (spinner) {
+      spinner.classList.toggle("visible", submitting);
     }
   };
 
-  const appendMessage = (container, text, author) => {
-    if (!container) return;
-    const message = document.createElement("div");
-    message.className = `chatbot-message ${author}`;
-    message.textContent = text;
-    container.appendChild(message);
-    container.scrollTop = container.scrollHeight;
-  };
+  form?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!form) return;
 
-  const resetForm = (form) => {
-    form.reset();
-    const firstInput = form.querySelector("input, textarea");
-    firstInput?.focus({ preventScroll: true });
-  };
-
-  document.addEventListener("DOMContentLoaded", () => {
-    const panel = document.querySelector(".chatbot-panel");
-    const toggles = Array.from(document.querySelectorAll(".chatbot-toggle"));
-    if (!panel || toggles.length === 0) return;
-
-    const closeButton = panel.querySelector("[data-chatbot-close]");
-    const messages = panel.querySelector("[data-chatbot-messages]");
-    const quickReplyButtons = panel.querySelectorAll("[data-chatbot-reply]");
-    const form = panel.querySelector("form");
-    const status = panel.querySelector("[data-chatbot-status]");
-    const spinner = panel.querySelector("[data-chatbot-spinner]");
-
-    toggles.forEach((toggle) => {
-      toggle.addEventListener("click", () => togglePanel(panel, toggles));
-    });
-
-    closeButton?.addEventListener("click", () => togglePanel(panel, toggles, false));
-
-    appendMessage(
-      messages,
-      "Hi there! I’m the Icarius assistant. Ask me about our services or leave a note and we’ll follow up.",
-      "bot"
-    );
-
-    quickReplyButtons.forEach((button) => {
-      button.addEventListener("click", () => {
-        const key = button.getAttribute("data-chatbot-reply");
-        const response = cannedResponses[key];
-        if (!response) return;
-        appendMessage(messages, button.textContent.trim(), "user");
-        window.setTimeout(() => {
-          appendMessage(messages, response, "bot");
-        }, 300);
-      });
-    });
-
-    const setStatus = (message, tone = "") => {
-      if (!status) return;
-      status.textContent = message;
-      status.classList.remove("error", "success");
-      if (tone) status.classList.add(tone);
+    const formData = new FormData(form);
+    const payload = {
+      name: sanitize(formData.get("name")),
+      email: sanitize(formData.get("email")),
+      company: sanitize(formData.get("company")),
+      message: sanitize(formData.get("message")),
+      source: "assistant-widget",
     };
 
-    const setSubmitting = (submitting) => {
-      if (!form) return;
-      Array.from(form.elements).forEach((element) => {
-        if ("disabled" in element) {
-          element.disabled = submitting;
-        }
-      });
-      if (spinner) {
-        spinner.classList.toggle("visible", submitting);
-      }
-    };
-
-    form?.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      if (!form) return;
-
-      const formData = new FormData(form);
-      const name = sanitize(formData.get("name"));
-      const email = sanitize(formData.get("email"));
-      const company = sanitize(formData.get("company"));
-      const message = sanitize(formData.get("message"));
-
-      const errors = [];
-      if (!name) errors.push("Please share your name.");
-      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      if (!emailPattern.test(email)) errors.push("Enter a valid email address.");
-      if (!message || message.length < 10) errors.push("Tell us a bit more so we can help.");
-
-      if (errors.length) {
-        setStatus(errors.join(" "), "error");
-        return;
-      }
-
-      setStatus("Sending your note...");
-      setSubmitting(true);
-
-      try {
-        const response = await fetch("/api/save-chat-request", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ name, email, company, message }),
-          credentials: "same-origin",
-        });
-
-        const payload = await response.json().catch(() => ({ success: false }));
-        if (!response.ok || !payload.success) {
-          const detail = payload.error || "We couldn’t send that. Please try again.";
-          throw new Error(detail);
-        }
-
-        appendMessage(
-          messages,
-          "Thanks for reaching out! A consultant will respond soon via email.",
-          "bot"
-        );
-        setStatus("Message sent successfully.", "success");
-        resetForm(form);
-      } catch (error) {
-        console.error("Chatbot submission failed", error);
-        setStatus(error.message || "We couldn’t send that. Please try again.", "error");
-      } finally {
-        setSubmitting(false);
-      }
+    const errors = validateContactFields(payload, {
+      messages: fieldMessages,
     });
+
+    if (Object.keys(errors).length) {
+      setStatus(Object.values(errors).join(" "), "error");
+      return;
+    }
+
+    setStatus("Sending your note…");
+    setSubmitting(true);
+
+    try {
+      await submitContactRequest(payload);
+      appendMessage(
+        messages,
+        "Thanks for reaching out! A consultant will respond soon via email.",
+        "bot",
+      );
+      setStatus("Message sent successfully.", "success");
+      resetForm(form);
+    } catch (error) {
+      console.error("Chatbot submission failed", error);
+      setStatus(error.message || "We couldn’t send that. Please try again.", "error");
+    } finally {
+      setSubmitting(false);
+    }
   });
-})();
+});

--- a/components/contact-request.js
+++ b/components/contact-request.js
@@ -1,0 +1,75 @@
+const emailPattern = /[^@\s]+@[^@\s]+\.[^@\s]+/;
+
+export const sanitize = (value) =>
+  String(value ?? "")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .replace(/[<>]/g, "")
+    .trim();
+
+export const validateContactFields = (
+  data,
+  {
+    messages = {},
+    minMessageLength = 10,
+  } = {}
+) => {
+  const defaults = {
+    name: "Please share your name.",
+    email: "Enter a valid email address.",
+    message:
+      minMessageLength > 1
+        ? `Please share at least ${minMessageLength} characters.`
+        : "Please share a short message.",
+  };
+
+  const errors = {};
+  if (!sanitize(data.name)) {
+    errors.name = messages.name || defaults.name;
+  }
+
+  const email = sanitize(data.email);
+  if (!emailPattern.test(email)) {
+    errors.email = messages.email || defaults.email;
+  }
+
+  const message = sanitize(data.message);
+  if (!message || message.length < minMessageLength) {
+    errors.message = messages.message || defaults.message;
+  }
+
+  return errors;
+};
+
+export const submitContactRequest = async (payload) => {
+  const preparedPayload = Object.entries(payload || {}).reduce(
+    (accumulator, [key, value]) => {
+      accumulator[key] = sanitize(value);
+      return accumulator;
+    },
+    {},
+  );
+
+  const response = await fetch("/api/contact", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(preparedPayload),
+    credentials: "same-origin",
+  });
+
+  let body = {};
+  try {
+    body = await response.json();
+  } catch (error) {
+    body = {};
+  }
+
+  if (!response.ok || !body?.ok) {
+    const message = body?.error || "We couldn't send your message. Please try again.";
+    throw new Error(message);
+  }
+
+  return body;
+};

--- a/contact.html
+++ b/contact.html
@@ -53,7 +53,7 @@
         <div class="contact-card">
           <h2>Share a few details</h2>
           <p>We'll respond within one business day. Required fields are marked with *</p>
-          <form action="https://formsubmit.co/contact@icarius-consulting.com" id="contact-form" method="POST" novalidate>
+          <form id="contact-form" method="POST" novalidate>
             <div class="field" data-field="name">
               <label for="name">Full name *</label>
               <input type="text" id="name" name="name" required autocomplete="name" />
@@ -96,81 +96,7 @@
       </nav>
     </div>
   </footer>
-  <script>
-    document.getElementById('year')?.textContent = new Date().getFullYear();
-    const form = document.getElementById('contact-form');
-    const statusMessage = document.getElementById('status-message');
-    const requiredFields = ['name', 'email', 'message'];
-
-    function validateEmail(value) {
-      return /[^@\s]+@[^@\s]+\.[^@\s]+/.test(value);
-    }
-
-    function clearStatus() {
-      statusMessage.textContent = '';
-      statusMessage.className = 'status-message';
-    }
-
-    form.addEventListener('input', (event) => {
-      const fieldWrapper = event.target.closest('.field');
-      if (!fieldWrapper) return;
-      fieldWrapper.classList.remove('error');
-      clearStatus();
-    });
-
-    form.addEventListener('submit', async (event) => {
-      event.preventDefault();
-      clearStatus();
-      let isValid = true;
-
-      requiredFields.forEach((fieldName) => {
-        const field = form.elements[fieldName];
-        const wrapper = field.closest('.field');
-        const value = field.value.trim();
-
-        if (!value || (fieldName === 'email' && !validateEmail(value))) {
-          wrapper.classList.add('error');
-          isValid = false;
-        } else {
-          wrapper.classList.remove('error');
-        }
-      });
-
-      if (!isValid) {
-        statusMessage.textContent = 'Please correct the highlighted fields.';
-        statusMessage.classList.add('error');
-        return;
-      }
-
-      statusMessage.textContent = 'Sending…';
-      const formData = new FormData(form);
-      const payload = Object.fromEntries(formData.entries());
-
-      try {
-        const response = await fetch(form.action, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-          },
-          body: JSON.stringify(payload)
-        });
-
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-
-        statusMessage.textContent = 'Thanks! We\'ll be in touch shortly.';
-        statusMessage.classList.add('success');
-        form.reset();
-      } catch (error) {
-        const mailBody = `Name: ${payload.name || ''}\nEmail: ${payload.email || ''}\nCompany: ${payload.company || ''}\n\nMessage:\n${payload.message || ''}`;
-        window.location.href = `mailto:contact@icarius-consulting.com?subject=Icarius%20Consulting%20Inquiry&body=${encodeURIComponent(mailBody)}`;
-        statusMessage.textContent = 'Launching your email client… if nothing happens, reach us at contact@icarius-consulting.com.';
-        statusMessage.classList.add('error');
-      }
-    });
-  </script>
+  <script type="module" src="contact.js"></script>
   <script async src="https://assets.calendly.com/assets/external/widget.js"></script>
 </body>
 </html>

--- a/contact.js
+++ b/contact.js
@@ -1,0 +1,96 @@
+import {
+  sanitize,
+  submitContactRequest,
+  validateContactFields,
+} from "./components/contact-request.js";
+
+document.getElementById("year")?.textContent = new Date().getFullYear();
+
+const form = document.getElementById("contact-form");
+const statusMessage = document.getElementById("status-message");
+const submitButton = form?.querySelector('button[type="submit"]');
+const baseStatusClass = statusMessage?.className || "";
+
+const setStatus = (message, tone) => {
+  if (!statusMessage) return;
+  statusMessage.textContent = message;
+  const classes = [baseStatusClass];
+  if (tone) classes.push(tone);
+  statusMessage.className = classes.filter(Boolean).join(" ");
+};
+
+const clearStatus = () => setStatus("", "");
+
+const setSubmitting = (submitting) => {
+  if (!submitButton) return;
+  submitButton.disabled = submitting;
+};
+
+const fieldNames = ["name", "email", "message"];
+
+const toggleFieldError = (fieldName, hasError) => {
+  if (!form) return;
+  const fieldWrapper = form.querySelector(`[data-field="${fieldName}"]`);
+  fieldWrapper?.classList.toggle("error", Boolean(hasError));
+};
+
+const showFieldErrors = (errors) => {
+  fieldNames.forEach((field) => {
+    toggleFieldError(field, errors[field]);
+  });
+};
+
+if (form) {
+  form.addEventListener("input", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const fieldName = target.getAttribute("name");
+    if (!fieldName || !fieldNames.includes(fieldName)) return;
+    toggleFieldError(fieldName, false);
+    clearStatus();
+  });
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    clearStatus();
+
+    const formData = new FormData(form);
+    const payload = {
+      name: sanitize(formData.get("name")),
+      email: sanitize(formData.get("email")),
+      message: sanitize(formData.get("message")),
+      company: sanitize(formData.get("company")),
+      source: "contact-page",
+    };
+
+    const errors = validateContactFields(payload, {
+      messages: {
+        name: "Please tell us your name.",
+        email: "Enter a valid work email address.",
+        message: "Please share a little about your needs.",
+      },
+    });
+
+    showFieldErrors(errors);
+
+    if (Object.keys(errors).length) {
+      setStatus("Please correct the highlighted fields.", "error");
+      return;
+    }
+
+    setStatus("Sending…");
+    setSubmitting(true);
+
+    try {
+      await submitContactRequest(payload);
+      setStatus("Thanks! We'll be in touch shortly.", "success");
+      form.reset();
+      fieldNames.forEach((field) => toggleFieldError(field, false));
+    } catch (error) {
+      console.error("Contact form submission failed", error);
+      setStatus(error.message || "We couldn't send your message. Please try again.", "error");
+    } finally {
+      setSubmitting(false);
+    }
+  });
+}

--- a/index.html
+++ b/index.html
@@ -192,6 +192,6 @@ fetch('/packages.json')
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
   <script src="/components/book-cta.js" defer></script>
-  <script src="/chatbot.js" defer></script>
+  <script type="module" src="/chatbot.js"></script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -127,6 +127,6 @@
     </form>
   </div>
   <script defer src="/components/book-cta.js"></script>
-  <script defer src="chatbot.js"></script>
+  <script type="module" src="chatbot.js"></script>
 </body>
 </html>

--- a/work.html
+++ b/work.html
@@ -165,6 +165,6 @@
     </form>
   </div>
   <script defer src="/components/book-cta.js"></script>
-  <script defer src="chatbot.js"></script>
+  <script type="module" src="chatbot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a serverless `/api/contact` handler that validates submissions and forwards them to `CONTACT_WEBHOOK_URL`
- introduce a shared client helper for contact validation/submission and refactor the contact page to use it with inline feedback
- update the chatbot assistant and page scripts to consume the shared helper and load the bot as an ES module

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68defdd7be048330b0a949caa41aee9f